### PR TITLE
Prepend . to config file, offer to move, offer to add to gitignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raisely/cli",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Raisely CLI for local development",
   "main": "./src/cli.js",
   "bin": {

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,92 @@
+import chalk from 'chalk';
+import ora from 'ora';
+import fs from 'fs';
+import path from 'path';
+import inquirer from 'inquirer';
+
+import { br, log, error } from './helpers';
+
+const CONFIG_FILE = '.raisely.json';
+
+async function legacyLoad() {
+    const legacyConfig = 'raisely.json';
+    const config = readConfig(legacyConfig);
+    // move to new config file
+    br();
+    log(`@raisely/cli now uses ${chalk.bold.white(CONFIG_FILE)}`);
+    const response = await inquirer
+        .prompt([
+            {
+                type: 'confirm',
+                name: 'confirm',
+                message: `Would you like to rename your old config (${chalk.underline(legacyConfig)}) to ${chalk.underline(CONFIG_FILE)} now?`,
+            }
+        ]);
+    if (response.confirm) {
+        fs.renameSync(legacyConfig, CONFIG_FILE);
+        await hideFile();
+    }
+
+    return config;
+}
+
+function readConfig(filename) {
+    const configJson = fs.readFileSync(path.join(process.cwd(), filename));
+    const config = JSON.parse(configJson);
+    return config;
+}
+
+async function hideFile() {
+    const cwdFiles = fs.readdirSync(process.cwd());
+    if (cwdFiles.find(n => n === '.git')) {
+        let isIgnored;
+        try {
+            const lines = fs.readFileSync('.gitignore', 'utf8');
+            isIgnored = lines
+                .split('\n')
+                .find(n => n === CONFIG_FILE);
+        } catch (e) {
+            // Assume that an error means the file doesn't exist
+        }
+        if (!isIgnored) {
+            log('You appear to be in a git repository.');
+            log(`To keep credentials out of source control, ${chalk.bold.white(CONFIG_FILE)} should be added to your .gitignore file`, 'white')
+            const response = await inquirer
+                .prompt([
+                    {
+                        type: 'confirm',
+                        name: 'confirm',
+                        message: `Would you like to add ${chalk.underline(CONFIG_FILE)} to your .gitignore now?`,
+                    }
+                ]);
+
+            if (response.confirm) {
+                const lineToAdd = '\n' + CONFIG_FILE + '\n';
+                fs.appendFileSync('.gitignore', lineToAdd);
+                return log(`${chalk.white.underline(CONFIG_FILE)} added to .gitignore`);
+            }
+        }
+    }
+}
+
+export async function loadConfig() {
+    let config;
+    try {
+        config = readConfig(CONFIG_FILE);
+    } catch(e) {
+        try {
+            config = await legacyLoad();
+        } catch (e2) {
+            return error(`No raisely.json found. Run ${chalk.bold.underline.white('raisely init')} to start.`);
+        }
+    }
+    return config;
+}
+
+export async function saveConfig(config) {
+    // write the raisely.json config file
+    const configLoader = ora(`Saving settings to ${CONFIG_FILE}...`).start();
+    fs.writeFileSync(path.join(process.cwd(), CONFIG_FILE), JSON.stringify(config, null, 4));
+    configLoader.succeed();
+    await hideFile();
+}

--- a/src/create.js
+++ b/src/create.js
@@ -1,12 +1,11 @@
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import ora from 'ora';
-import fs from 'fs';
-import path from 'path';
 
 import { welcome, log, br, error } from './helpers';
 import { syncComponents } from './actions/sync';
 import { createComponent } from './actions/components';
+import { loadConfig } from './config';
 
 export default function create(program) {
 
@@ -14,16 +13,11 @@ export default function create(program) {
     .command('create')
     .action(async (name, cmd) => {
 
-        // load config
-        let config;
-        try {
-            const configJson = fs.readFileSync(path.join(process.cwd(), 'raisely.json'));
-            config = JSON.parse(configJson);
-        } catch(e) {
-            return error(`No raisely.json found. Run ${chalk.bold.underline.white('raisely init')} to start.`);
-        }
-
         welcome();
+
+        // load config
+        let config = await loadConfig();
+
         log(`You are creating a new custom component. The component will be downloaded to:`, 'white')
         br();
         console.log(`    ${chalk.inverse(`${process.cwd()}`)}`);

--- a/src/init.js
+++ b/src/init.js
@@ -1,13 +1,12 @@
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import ora from 'ora';
-import fs from 'fs';
-import path from 'path';
 
 import { welcome, log, br, error } from './helpers';
 import { login } from './actions/auth';
 import { getCampaigns } from './actions/campaigns';
 import { syncStyles, syncComponents } from './actions/sync';
+import { saveConfig } from './config';
 
 export default function init(program) {
 
@@ -76,14 +75,11 @@ export default function init(program) {
                 }
             ])
 
-        // write the raisely.json config file
-        const configLoader = ora('Saving settings to raisely.json...').start()
         const config = {
             token: data.token,
             campaigns: campaigns.campaigns
-        }
-        fs.writeFileSync(path.join(process.cwd(), 'raisely.json'), JSON.stringify(config, null, 4));
-        configLoader.succeed();
+        };
+        await saveConfig(config);
 
         // sync down campaign stylesheets
         await syncStyles(config, process.cwd());

--- a/src/start.js
+++ b/src/start.js
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import inquirer from 'inquirer';
 import ora from 'ora';
 import fs from 'fs';
 import path from 'path';
@@ -7,6 +6,7 @@ import path from 'path';
 import { welcome, log, br, error } from './helpers';
 import { updateStyles } from './actions/campaigns';
 import { updateComponentFile, updateComponentConfig } from './actions/components';
+import { loadConfig } from './config';
 
 export default function start(program) {
 
@@ -14,16 +14,11 @@ export default function start(program) {
     .command('start')
     .action(async (dir, cmd) => {
 
-        // load config
-        let config;
-        try {
-            const configJson = fs.readFileSync(path.join(process.cwd(), 'raisely.json'));
-            config = JSON.parse(configJson);
-        } catch(e) {
-            return error(`No raisely.json found. Run ${chalk.bold.underline.white('raisely init')} to start.`);
-        }
-
         welcome();
+
+        // load config
+        const config = await loadConfig();
+
         log(`Watching and uploading changes in this directory`, 'white');
         br();
         console.log(`    ${chalk.inverse(`${process.cwd()}`)}`);

--- a/src/update.js
+++ b/src/update.js
@@ -1,21 +1,15 @@
 import chalk from 'chalk';
 import inquirer from 'inquirer';
-import ora from 'ora';
-import fs from 'fs';
-import path from 'path';
 
-import { welcome, log, br, error } from './helpers';
-import { login } from './actions/auth';
-import { getCampaigns } from './actions/campaigns';
+import { welcome, log, br } from './helpers';
 import { syncStyles, syncComponents } from './actions/sync';
+import { loadConfig } from './config';
 
 export default function update(program) {
 
     program
     .command('update')
     .action(async (dir, cmd) => {
-
-        const data = {};
 
         welcome();
         log(`You are about to update the styles and components in this directory`, 'white')
@@ -41,13 +35,7 @@ export default function update(program) {
         }
 
         // load config
-        let config;
-        try {
-            const configJson = fs.readFileSync(path.join(process.cwd(), 'raisely.json'));
-            config = JSON.parse(configJson);
-        } catch(e) {
-            return error(`No raisely.json found. Run ${chalk.bold.underline.white('raisely init')} to start.`);
-        }
+        const config = await loadConfig();
 
         // sync down campaign stylesheets
         await syncStyles(config, process.cwd());


### PR DESCRIPTION
Better security by default for credentials
* Rename `raisely.json` to `.raisely.json` to hint that it's a special file
* Offer to add `.raisely.json` to `.gitignore` if it's not there already
* Offer to rename to `.raisely.json` for clients that have updated from an old client

Fixes https://zube.io/agency/raisely/c/6020