### PR TITLE
Add support for folders and multiple SCSS files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,34 @@
 {
 	"name": "@raisely/cli",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@types/events": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+		},
+		"@types/glob": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"requires": {
+				"@types/events": "*",
+				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
+		"@types/minimatch": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+		},
+		"@types/node": {
+			"version": "13.7.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
+			"integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ=="
+		},
 		"ajv": {
 			"version": "6.10.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
@@ -61,12 +86,26 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
 		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"requires": {
 				"tweetnacl": "^0.14.3"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
 			}
 		},
 		"caseless": {
@@ -137,6 +176,11 @@
 			"version": "2.20.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
 			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -236,12 +280,38 @@
 				"mime-types": "^2.1.12"
 			}
 		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
 				"assert-plus": "^1.0.0"
+			}
+		},
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"glob-promise": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-3.4.0.tgz",
+			"integrity": "sha512-q08RJ6O+eJn+dVanerAndJwIcumgbDdYiUT7zFQl3Wm1xD6fBKtah7H8ZJChj4wP+8C+QfeVy8xautR7rdmKEw==",
+			"requires": {
+				"@types/glob": "*"
 			}
 		},
 		"har-schema": {
@@ -280,6 +350,20 @@
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"inquirer": {
 			"version": "6.3.1",
@@ -383,6 +467,14 @@
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
 			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -392,6 +484,14 @@
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
 			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1"
+			}
 		},
 		"onetime": {
 			"version": "2.0.1",
@@ -418,6 +518,11 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"performance-now": {
 			"version": "2.1.0",
@@ -664,6 +769,11 @@
 			"requires": {
 				"defaults": "^1.0.3"
 			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@raisely/cli",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "Raisely CLI for local development",
 	"main": "./src/cli.js",
 	"bin": {
@@ -15,6 +15,8 @@
 		"chalk": "^2.4.2",
 		"commander": "^2.20.0",
 		"esm": "^3.2.25",
+		"glob": "^7.1.6",
+		"glob-promise": "^3.4.0",
 		"inquirer": "^6.3.1",
 		"lodash": "^4.17.11",
 		"ora": "^3.4.0",

--- a/src/actions/campaigns.js
+++ b/src/actions/campaigns.js
@@ -13,7 +13,7 @@ export async function getCampaigns({ organisationId }, token, opts = {}) {
 	);
 }
 
-export async function updateStyles({ path, css }, config) {
+export async function updateStyles({ path, files, css }, config) {
 	const campaign = await api(
 		{
 			path: `/campaigns/${path}`,
@@ -25,15 +25,19 @@ export async function updateStyles({ path, css }, config) {
 		},
 		config.apiUrl
 	);
+
+	const data = Object.assign({}, campaign.data.config.css, {
+		files,
+		custom_css: css
+	});
+
 	return await api(
 		{
 			path: `/campaigns/${path}/config/css`,
 			qs: { private: 1 },
 			method: "PATCH",
 			json: {
-				data: Object.assign(campaign.data.config.css, {
-					custom_css: css
-				})
+				data
 			},
 			auth: {
 				bearer: config.token

--- a/src/actions/sync.js
+++ b/src/actions/sync.js
@@ -24,8 +24,37 @@ export async function syncStyles(config, workDir) {
 				config.apiUrl
 			);
 
+			const campaignDir = path.join(directory, campaign.data.path);
+
+			if (!fs.existsSync(campaignDir)) {
+				fs.mkdirSync(campaignDir);
+			}
+
+			if (campaign.data.config.css.files) {
+				const files = campaign.data.config.css.files;
+
+				for (const file of Object.keys(
+					campaign.data.config.css.files
+				)) {
+					const fileFolder = file
+						.split("/")
+						.filter(f => !f.includes("."));
+					const fileName = file
+						.split("/")
+						.filter(f => f.includes("."))
+						.join("");
+					const fileDir = path.join(campaignDir, ...fileFolder);
+
+					if (!fs.existsSync(fileDir)) {
+						fs.mkdirSync(fileDir, { recursive: true });
+					}
+
+					fs.writeFileSync(path.join(fileDir, fileName), files[file]);
+				}
+			}
+
 			fs.writeFileSync(
-				path.join(directory, `${campaign.data.path}.scss`),
+				path.join(campaignDir, `${campaign.data.path}.scss`),
 				campaign.data.config.css.custom_css
 			);
 		}

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,7 +6,7 @@ import start from "./start";
 import create from "./create";
 
 export async function cli(args) {
-	program.version("1.2.0");
+	program.version("1.3.0");
 	program.option("-a, --api <api>", "custom api url");
 
 	init(program);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -13,7 +13,7 @@ export function welcome() {
 	log(
 		`
 ******************************
-Raisely CLI (1.2.0)
+Raisely CLI (1.3.0)
 ******************************
         `,
 		"magenta"

--- a/src/start.js
+++ b/src/start.js
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import fs from "fs";
 import path from "path";
+import glob from "glob-promise";
 
 import { welcome, log, br, error } from "./helpers";
 import { updateStyles } from "./actions/campaigns";
@@ -34,19 +35,44 @@ export default function start(program) {
 		const componentsDir = path.join(process.cwd(), "components");
 		fs.watch(
 			stylesDir,
-			{ encoding: "utf8" },
+			{ encoding: "utf8", recursive: true },
 			async (eventType, filename) => {
 				const loader = ora(`Saving ${filename}`).start();
+
+				const filePath = filename.split("/")[0];
+
+				const files = await glob(
+					`${path.join(stylesDir, filePath)}/**/*.scss`
+				);
+
+				const configFiles = {};
+				for (const file of files) {
+					const fileName = file
+						.replace(`${stylesDir}/`, "")
+						.replace(`${filePath}/`, "");
+
+					// continue if this is the main stylesheet
+					if (fileName === `${filePath}.scss`) continue;
+
+					configFiles[
+						file
+							.replace(`${stylesDir}/`, "")
+							.replace(`${filePath}/`, "")
+					] = fs.readFileSync(file, "utf8");
+				}
+
 				await updateStyles(
 					{
-						path: filename.replace(".scss", ""),
+						path: filePath,
+						files: configFiles,
 						css: fs.readFileSync(
-							path.join(stylesDir, filename),
+							path.join(stylesDir, filePath, `${filePath}.scss`),
 							"utf8"
 						)
 					},
 					config
 				);
+
 				loader.succeed();
 			}
 		);

--- a/src/update.js
+++ b/src/update.js
@@ -8,19 +8,7 @@ import { loadConfig } from "./config";
 export default function update(program) {
 	program.command("update").action(async (dir, cmd) => {
 		// load config
-		let config;
-		try {
-			const configJson = fs.readFileSync(
-				path.join(process.cwd(), "raisely.json")
-			);
-			config = JSON.parse(configJson);
-		} catch (e) {
-			return error(
-				`No raisely.json found. Run ${chalk.bold.underline.white(
-					"raisely init"
-				)} to start.`
-			);
-		}
+		let config = await loadConfig();
 
 		const data = {};
 


### PR DESCRIPTION
This  moves campaign SCSS files into folders. Each campaign will have one file by default, ie:

/styles/[campaignPath]/[campaignPath].scss

But, developers can add new folders and .scss files into this folder, which will be synced up to the API. They are concatenated together by file name. @imports not allowed between files.