### PR TITLE
Feature/improved login experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@raisely/cli",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"description": "Raisely CLI for local development",
 	"main": "./src/cli.js",
 	"bin": {

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -1,4 +1,35 @@
 import api from "./api";
+import jsonDeocde from 'json-decode';
+
+let token = null;
+let tokenExpiresAt = null;
+
+/**
+ * Return true if a token has an exp and it's in the past or the next 24 hours
+ * (easier to update password at the start of the session than notice it needs
+ * updating 10 minutes in)
+ * @returns {boolean}
+ */
+function tokenExpiresSoon() {
+	if (tokenExpiresAt) {
+		const window = 24 * 60 * 60 * 1000;
+		const expiresWindow = new Date().getTime() + window;
+		return tokenExpiresAt.getTime() < expiresWindow;
+	}
+	return false;
+}
+
+function setTokenExpiresAt() {
+	if (tokenExpiresAt === null) {
+		tokenExpiresAt = false;
+		try {
+			const decoded = jsonDeocde(token);
+			tokenExpiresAt = new Date(decoded.exp * 1000);
+		} catch (e) {
+			console.warn("Could not decode token, is it a JWT?");
+		}
+	}
+}
 
 export async function login(body, opts = {}) {
 	return await api(
@@ -9,4 +40,16 @@ export async function login(body, opts = {}) {
 		},
 		opts.apiUrl
 	);
+}
+
+export async function getToken() {
+	if (!token) ({ token }) = loadConfig();
+	setTokenExpiresAt();
+	if (tokenExpiresSoon()) {
+		({ token } = await doLogin('Your token has expired, please login again'));
+		setTokenExpiresAt();
+		await updateConfig({ token });
+	}
+
+	return token;
 }

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -54,7 +54,7 @@ export async function getToken(warnEarly) {
 		({ token }) = await loadConfig();
 		setTokenExpiresAt();
 	}
-	if (tokenExpiresSoon(warnEarly)) {
+	if (isTokenExpired(warnEarly)) {
 		({ token } = await doLogin('Your token has expired, please login again'));
 		setTokenExpiresAt();
 		await updateConfig({ token });

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -1,5 +1,7 @@
-import api from "./api";
 import jsonDeocde from 'json-decode';
+
+import api from "./api";
+import { loadConfig } from "../config";
 
 let token = null;
 let tokenExpiresAt = null;
@@ -43,8 +45,10 @@ export async function login(body, opts = {}) {
 }
 
 export async function getToken() {
-	if (!token) ({ token }) = loadConfig();
-	setTokenExpiresAt();
+	if (!token) {
+		({ token }) = await loadConfig();
+		setTokenExpiresAt();
+	}
 	if (tokenExpiresSoon()) {
 		({ token } = await doLogin('Your token has expired, please login again'));
 		setTokenExpiresAt();

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,9 +5,12 @@ import update from "./update";
 import start from "./start";
 import create from "./create";
 import deploy from "./deploy";
+import login from "./login";
+
+const { version } = require('package.json');
 
 export async function cli(args) {
-	program.version("1.4.0");
+	program.version(version);
 	program.option("-a, --api <api>", "custom api url");
 
 	init(program);
@@ -15,6 +18,7 @@ export async function cli(args) {
 	start(program);
 	create(program);
 	deploy(program);
+	login(program);
 
 	program.parse(process.argv);
 }

--- a/src/config.js
+++ b/src/config.js
@@ -115,3 +115,21 @@ export async function saveConfig(config) {
 	configLoader.succeed();
 	await hideFile();
 }
+
+export async function updateConfig(updates) {
+	// write the raisely.json config file
+	const configLoader = ora(
+		`Updating settings in ${CONFIG_FILE}...`
+	).start();
+	let config = await loadConfig();
+	const newConfig = {
+		...config,
+		...updates
+	};
+	fs.writeFileSync(
+		path.join(process.cwd(), CONFIG_FILE),
+		JSON.stringify(newConfig, null, 4)
+	);
+	configLoader.succeed();
+	await hideFile();
+}

--- a/src/init.js
+++ b/src/init.js
@@ -7,6 +7,7 @@ import { login } from "./actions/auth";
 import { getCampaigns } from "./actions/campaigns";
 import { syncStyles, syncComponents } from "./actions/sync";
 import { saveConfig } from "./config";
+import { doLogin } from "./login";
 
 export default function init(program) {
 	program.command("init").action(async (dir, cmd) => {
@@ -23,36 +24,8 @@ export default function init(program) {
 		log(`Log in to your Raisely account to start:`, "white");
 		br();
 
-		// collect login details
-		const credentials = await inquirer.prompt([
-			{
-				type: "input",
-				name: "username",
-				message: "Enter your email address",
-				validate: value =>
-					value.length ? true : "Please enter your email address"
-			},
-			{
-				type: "password",
-				message: "Enter your password",
-				name: "password",
-				validate: value =>
-					value.length ? true : "Please enter a password"
-			}
-		]);
-
-		// log the user in
-		const loginLoader = ora("Logging you in...").start();
 		try {
-			data.user = await login(
-				{
-					...credentials,
-					requestAdminToken: true
-				},
-				{ apiUrl: program.api }
-			);
-			data.token = data.user.token;
-			loginLoader.succeed();
+			const { user, token } = await doLogin();
 		} catch (e) {
 			return error(e, loginLoader);
 		}
@@ -83,7 +56,7 @@ export default function init(program) {
 		]);
 
 		const config = {
-			token: data.token,
+			token,
 			campaigns: campaigns.campaigns
 		};
 		if (program.api) config.apiUrl = program.api;

--- a/src/init.js
+++ b/src/init.js
@@ -3,7 +3,6 @@ import inquirer from "inquirer";
 import ora from "ora";
 
 import { welcome, log, br, error } from "./helpers";
-import { login } from "./actions/auth";
 import { getCampaigns } from "./actions/campaigns";
 import { syncStyles, syncComponents } from "./actions/sync";
 import { saveConfig } from "./config";

--- a/src/login.js
+++ b/src/login.js
@@ -1,5 +1,6 @@
 import inquirer from "inquirer";
 import ora from "ora";
+import { login } from "./actions/auth";
 
 import { updateConfig } from "./config";
 
@@ -40,7 +41,7 @@ export async function doLogin(message) {
 	return { user, token };
 }
 
-export default function login(program) {
+export default function loginAction(program) {
 	program.command("login").action(async (dir, cmd) => {
 		try {
 			await doLogin(ora)

--- a/src/login.js
+++ b/src/login.js
@@ -28,14 +28,14 @@ export async function doLogin(message) {
 	// log the user in
 	const loginLoader = ora("Logging you in...").start();
 
-	const user = await login(
+	const loginBody = await login(
 		{
 			...credentials,
 			requestAdminToken: true
 		},
 		{ apiUrl: program.api }
 	);
-	const { token } = data.user;
+	const { token, user } = loginBody;
 	loginLoader.succeed();
 
 	return { user, token };
@@ -44,12 +44,13 @@ export async function doLogin(message) {
 export default function loginAction(program) {
 	program.command("login").action(async (dir, cmd) => {
 		try {
-			await doLogin(ora)
+			const { token, user } = await doLogin(ora)
+			await updateConfig({
+				token,
+				organisationUuid: user.organisationUuid,
+			});
 		} catch (e) {
 			return error(e, loginLoader);
 		}
-		await updateConfig({
-			token,
-		});
 	});
 }

--- a/src/login.js
+++ b/src/login.js
@@ -1,0 +1,54 @@
+import inquirer from "inquirer";
+import ora from "ora";
+
+import { updateConfig } from "./config";
+
+export async function doLogin(message) {
+	if (message) log(message, "white");
+
+	// collect login details
+	const credentials = await inquirer.prompt([
+		{
+			type: "input",
+			name: "username",
+			message: "Enter your email address",
+			validate: value =>
+				value.length ? true : "Please enter your email address"
+		},
+		{
+			type: "password",
+			message: "Enter your password",
+			name: "password",
+			validate: value =>
+				value.length ? true : "Please enter a password"
+		}
+	]);
+
+	// log the user in
+	const loginLoader = ora("Logging you in...").start();
+
+	const user = await login(
+		{
+			...credentials,
+			requestAdminToken: true
+		},
+		{ apiUrl: program.api }
+	);
+	const { token } = data.user;
+	loginLoader.succeed();
+
+	return { user, token };
+}
+
+export default function login(program) {
+	program.command("login").action(async (dir, cmd) => {
+		try {
+			await doLogin(ora)
+		} catch (e) {
+			return error(e, loginLoader);
+		}
+		await updateConfig({
+			token,
+		});
+	});
+}

--- a/src/start.js
+++ b/src/start.js
@@ -18,6 +18,8 @@ export default function start(program) {
 
 		// load config
 		const config = await loadConfig();
+		// Load token, which will prompt a login if the token is expired
+		config.token = await getToken();
 
 		log(`Watching and uploading changes in this directory`, "white");
 		br();
@@ -38,6 +40,7 @@ export default function start(program) {
 			{ encoding: "utf8", recursive: true },
 			async (eventType, filename) => {
 				const loader = ora(`Saving ${filename}`).start();
+				config.token = await getToken();
 
 				await buildStyles(filename, config);
 
@@ -50,6 +53,8 @@ export default function start(program) {
 			{ encoding: "utf8", recursive: true },
 			async (eventType, filename) => {
 				const loader = ora(`Saving ${filename}`).start();
+				config.token = await getToken();
+
 				try {
 					if (filename.includes(".json")) {
 						await updateComponentConfig(

--- a/src/start.js
+++ b/src/start.js
@@ -19,7 +19,7 @@ export default function start(program) {
 		// load config
 		const config = await loadConfig();
 		// Load token, which will prompt a login if the token is expired
-		config.token = await getToken();
+		config.token = await getToken(warnEarly);
 
 		log(`Watching and uploading changes in this directory`, "white");
 		br();

--- a/src/update.js
+++ b/src/update.js
@@ -11,7 +11,7 @@ export default function update(program) {
 		let config = await loadConfig();
 
 		// Load token, which will prompt a login if the token is expired
-		config.token = await getToken();
+		config.token = await getToken(warnEarly);
 
 		const data = {};
 

--- a/src/update.js
+++ b/src/update.js
@@ -10,6 +10,9 @@ export default function update(program) {
 		// load config
 		let config = await loadConfig();
 
+		// Load token, which will prompt a login if the token is expired
+		config.token = await getToken();
+
 		const data = {};
 
 		welcome();


### PR DESCRIPTION
Code has not yet been tested

* Adds a login command that can be used to update credentials without having to go through all settings
* Automatically checks token expiry and prompts to re-login if it's expired
* When running `raisely start` will prompt to re-login if token expires soon so it doesn't go unnoticed and cause confusion during development
* Checks organisationUuid against the token to fail fast if user account has been switched out
* Offers to switch a user back to the correct org if they are switched out

Fixes raisely/raisely#1126