### PR TITLE
Feature/note update & improve login

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,jsx,html,sass,less,jade,pug,json,css}]
+charset = utf-8
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# 1.4.1
+
+- Gracefully handle expired tokens and offer to log user in
+- Add `raisely login` command to manually change login
+- Offer to switch user to the correct account if they are logged into another
+- Notify the user when updates to the cli are available
+
+# 1.4.0
+
+- Add support for [CI/CD](https://github.com/raisely/cli#cicd-usage) with `raisely deploy`
+
+# 1.3.0
+
+- Add support for folders and multiple SCSS files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@raisely/cli",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -435,6 +435,11 @@
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
 			}
+		},
+		"jwt-decode": {
+			"version": "3.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.0.0-beta.2.tgz",
+			"integrity": "sha512-AnENY5syz7PzgpTzos9sxkqKTmHU0JeJOXZFHUc41bDyybC2yzZ+1r43ZLhk7+JCwF0yjISPuVK9ZWfA1nCUPA=="
 		},
 		"lodash": {
 			"version": "4.17.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@raisely/cli",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"description": "Raisely CLI for local development",
 	"main": "./src/cli.js",
 	"bin": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"glob": "^7.1.6",
 		"glob-promise": "^3.4.0",
 		"inquirer": "^6.3.1",
+		"jwt-decode": "^3.0.0-beta.2",
 		"lodash": "^4.17.11",
 		"ora": "^3.4.0",
 		"request": "^2.88.0",

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -1,4 +1,35 @@
 import api from "./api";
+import jsonDeocde from 'json-decode';
+
+let token = null;
+let tokenExpiresAt = null;
+
+/**
+ * Return true if a token has an exp and it's in the past or the next 24 hours
+ * (easier to update password at the start of the session than notice it needs
+ * updating 10 minutes in)
+ * @returns {boolean}
+ */
+function tokenExpiresSoon() {
+	if (tokenExpiresAt) {
+		const window = 24 * 60 * 60 * 1000;
+		const expiresWindow = new Date().getTime() + window;
+		return tokenExpiresAt.getTime() < expiresWindow;
+	}
+	return false;
+}
+
+function setTokenExpiresAt() {
+	if (tokenExpiresAt === null) {
+		tokenExpiresAt = false;
+		try {
+			const decoded = jsonDeocde(token);
+			tokenExpiresAt = new Date(decoded.exp * 1000);
+		} catch (e) {
+			console.warn("Could not decode token, is it a JWT?");
+		}
+	}
+}
 
 export async function login(body, opts = {}) {
 	return await api(
@@ -9,4 +40,16 @@ export async function login(body, opts = {}) {
 		},
 		opts.apiUrl
 	);
+}
+
+export async function getToken() {
+	if (!token) ({ token }) = loadConfig();
+	setTokenExpiresAt();
+	if (tokenExpiresSoon()) {
+		({ token } = await doLogin('Your token has expired, please login again'));
+		setTokenExpiresAt();
+		await updateConfig({ token });
+	}
+
+	return token;
 }

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -54,7 +54,7 @@ export async function getToken(warnEarly) {
 		({ token }) = await loadConfig();
 		setTokenExpiresAt();
 	}
-	if (tokenExpiresSoon(warnEarly)) {
+	if (isTokenExpired(warnEarly)) {
 		({ token } = await doLogin('Your token has expired, please login again'));
 		setTokenExpiresAt();
 		await updateConfig({ token });

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -44,7 +44,6 @@ function setTokenExpiresAt() {
 
 async function checkCorrectOrganisation(orgUuid, opts, currentOrganisation) {
 	let organisationUuid = orgUuid;
-	console.log("Checking", organisationUuid, opts.campaigns[0]);
 	if (!organisationUuid) {
 		const permChecker = ora("Checking campaign permissions...").start();
 		try {

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -1,5 +1,7 @@
-import api from "./api";
 import jsonDeocde from 'json-decode';
+
+import api from "./api";
+import { loadConfig } from "../config";
 
 let token = null;
 let tokenExpiresAt = null;
@@ -43,8 +45,10 @@ export async function login(body, opts = {}) {
 }
 
 export async function getToken() {
-	if (!token) ({ token }) = loadConfig();
-	setTokenExpiresAt();
+	if (!token) {
+		({ token }) = await loadConfig();
+		setTokenExpiresAt();
+	}
 	if (tokenExpiresSoon()) {
 		({ token } = await doLogin('Your token has expired, please login again'));
 		setTokenExpiresAt();

--- a/src/cli.js
+++ b/src/cli.js
@@ -7,7 +7,7 @@ import create from "./create";
 import deploy from "./deploy";
 import login from "./login";
 
-const { version } = require('package.json');
+import { version } from '../package.json';
 
 export async function cli(args) {
 	program.version(version);

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,9 +5,12 @@ import update from "./update";
 import start from "./start";
 import create from "./create";
 import deploy from "./deploy";
+import login from "./login";
+
+const { version } = require('package.json');
 
 export async function cli(args) {
-	program.version("1.4.0");
+	program.version(version);
 	program.option("-a, --api <api>", "custom api url");
 
 	init(program);
@@ -15,6 +18,7 @@ export async function cli(args) {
 	start(program);
 	create(program);
 	deploy(program);
+	login(program);
 
 	program.parse(process.argv);
 }

--- a/src/config.js
+++ b/src/config.js
@@ -85,7 +85,8 @@ export async function loadConfig() {
 			token: process.env.RAISELY_TOKEN,
 			cli: true,
 			apiUrl: process.env.RAISELY_API_URL,
-			campaigns: process.env.RAISELY_CAMPAIGNS.split(",")
+			campaigns: process.env.RAISELY_CAMPAIGNS.split(","),
+			$tokenFromEnv: true,
 		};
 	}
 

--- a/src/config.js
+++ b/src/config.js
@@ -115,3 +115,21 @@ export async function saveConfig(config) {
 	configLoader.succeed();
 	await hideFile();
 }
+
+export async function updateConfig(updates) {
+	// write the raisely.json config file
+	const configLoader = ora(
+		`Updating settings in ${CONFIG_FILE}...`
+	).start();
+	let config = await loadConfig();
+	const newConfig = {
+		...config,
+		...updates
+	};
+	fs.writeFileSync(
+		path.join(process.cwd(), CONFIG_FILE),
+		JSON.stringify(newConfig, null, 4)
+	);
+	configLoader.succeed();
+	await hideFile();
+}

--- a/src/create.js
+++ b/src/create.js
@@ -17,7 +17,7 @@ export default function create(program) {
 
 			// load config
 			let config = await loadConfig();
-			await getToken(config);
+			await getToken(program, config);
 
 			log(
 				`You are creating a new custom component${
@@ -36,12 +36,12 @@ export default function create(program) {
 						type: "input",
 						name: "name",
 						message: "Name of your component",
-						validate: value => {
+						validate: (value) => {
 							return value && /^[a-z0-9-]+$/.test(value)
 								? true
 								: 'Name can only use lowercase letters, "-" and numbers';
-						}
-					}
+						},
+					},
 				]);
 				name = response.name;
 			}

--- a/src/create.js
+++ b/src/create.js
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import inquirer from "inquirer";
 import ora from "ora";
 
-import { welcome, log, br, error } from "./helpers";
+import { welcome, log, br, error, informUpdate } from "./helpers";
 import { syncComponents } from "./actions/sync";
 import { createComponent } from "./actions/components";
 import { loadConfig } from "./config";
@@ -65,5 +65,6 @@ export default function create(program) {
 				)} to begin.`,
 				"green"
 			);
+			await informUpdate();
 		});
 }

--- a/src/create.js
+++ b/src/create.js
@@ -6,6 +6,7 @@ import { welcome, log, br, error, informUpdate } from "./helpers";
 import { syncComponents } from "./actions/sync";
 import { createComponent } from "./actions/components";
 import { loadConfig } from "./config";
+import { getToken } from "./actions/auth";
 
 export default function create(program) {
 	program
@@ -16,6 +17,7 @@ export default function create(program) {
 
 			// load config
 			let config = await loadConfig();
+			await getToken(config);
 
 			log(
 				`You are creating a new custom component${

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -11,11 +11,13 @@ import {
 	updateComponentConfig
 } from "./actions/components";
 import { loadConfig } from "./config";
+import { getToken } from "./actions/auth";
 
 export default function deploy(program) {
 	program.command("deploy").action(async (dir, cmd) => {
 		// load config
 		let config = await loadConfig();
+		await getToken(config);
 
 		welcome();
 		log(`You are about to deploy your local directly to Raisely`, "white");

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -8,7 +8,7 @@ import { welcome, log, br, informUpdate } from "./helpers";
 import { buildStyles, getCampaign } from "./actions/campaigns";
 import {
 	updateComponentFile,
-	updateComponentConfig
+	updateComponentConfig,
 } from "./actions/components";
 import { loadConfig } from "./config";
 import { getToken } from "./actions/auth";
@@ -17,7 +17,7 @@ export default function deploy(program) {
 	program.command("deploy").action(async (dir, cmd) => {
 		// load config
 		let config = await loadConfig();
-		await getToken(config);
+		await getToken(program, config);
 
 		welcome();
 		log(`You are about to deploy your local directly to Raisely`, "white");
@@ -41,8 +41,8 @@ export default function deploy(program) {
 				{
 					type: "confirm",
 					name: "confirm",
-					message: "Are you sure you want to continue?"
-				}
+					message: "Are you sure you want to continue?",
+				},
 			]);
 
 			if (!response.confirm) {
@@ -88,7 +88,7 @@ export default function deploy(program) {
 						path.join(componentsDir, file, `${file}.json`),
 						"utf8"
 					)
-				)
+				),
 			};
 
 			await updateComponentConfig(data, config);

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -4,7 +4,7 @@ import ora from "ora";
 import fs from "fs";
 import path from "path";
 
-import { welcome, log, br, error } from "./helpers";
+import { welcome, log, br, informUpdate } from "./helpers";
 import { buildStyles, getCampaign } from "./actions/campaigns";
 import {
 	updateComponentFile,
@@ -92,6 +92,7 @@ export default function deploy(program) {
 			await updateComponentConfig(data, config);
 			await updateComponentFile(data, config);
 			loader.succeed();
+			await informUpdate();
 		}
 
 		br();

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,26 @@
 import chalk from "chalk";
 import get from "lodash/get";
+import request from "request-promise-native";
+import modConfig from "../package.json";
+
+let updatePromise;
+let latestVersion;
+
+function checkUpdate() {
+	if (!updatePromise) {
+		const url = `https://registry.npmjs.org/-/package/${modConfig.name}/dist-tags`;
+		updatePromise = request({
+			url,
+			json: true
+		})
+		.then(result => {			
+			latestVersion = result.latest;
+		})
+		.catch(e => {
+			// noop 
+		})
+	}
+}
 
 export function log(message, color) {
 	console.log(chalk[color || "white"](message));
@@ -10,14 +31,32 @@ export function br() {
 }
 
 export function welcome() {
+	checkUpdate();
 	log(
 		`
 ******************************
-Raisely CLI (1.4.0)
+Raisely CLI (${modConfig.version})
 ******************************
         `,
 		"magenta"
 	);
+}
+
+export async function informUpdate() {
+	if (updatePromise) {
+		await updatePromise;
+		if (latestVersion > modConfig.version) {
+			log(
+`
+A new version of the Raisely cli is available (${latestVersion}), to update, run:
+		npm update @raisely/cli
+`,
+
+        "white"
+      );
+		}
+	}
+
 }
 
 export function error(e, loader) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -11,14 +11,14 @@ function checkUpdate() {
 		const url = `https://registry.npmjs.org/-/package/${modConfig.name}/dist-tags`;
 		updatePromise = request({
 			url,
-			json: true
+			json: true,
 		})
-		.then(result => {			
-			latestVersion = result.latest;
-		})
-		.catch(e => {
-			// noop 
-		})
+			.then((result) => {
+				latestVersion = result.latest;
+			})
+			.catch((e) => {
+				// noop
+			});
 	}
 }
 
@@ -47,16 +47,17 @@ export async function informUpdate() {
 		await updatePromise;
 		if (latestVersion > modConfig.version) {
 			log(
-`
-A new version of the Raisely cli is available (${latestVersion}), to update, run:
+				`
+A new version of the Raisely cli is available (${latestVersion}),
+See changes at: https://github.com/raisely/cli/blob/master/CHANGELOG.md
+To update, run:
 		npm update @raisely/cli
 `,
 
-        "white"
-      );
+				"white"
+			);
 		}
 	}
-
 }
 
 export function error(e, loader) {

--- a/src/init.js
+++ b/src/init.js
@@ -23,16 +23,15 @@ export default function init(program) {
 		log(`Log in to your Raisely account to start:`, "white");
 		br();
 
-		try {
-			const { user, token } = await doLogin();
-		} catch (e) {
-			return error(e, loginLoader);
-		}
+		const result = await doLogin(program);
+        if (!result) return;
+
+		const { user, token } = result;
 
 		// load the campaigns
 		const campaignsLoader = ora("Loading your campaigns...").start();
 		try {
-			data.campaigns = await getCampaigns({}, data.token, {
+			data.campaigns = await getCampaigns({}, token, {
 				apiUrl: program.api
 			});
 			campaignsLoader.succeed();

--- a/src/init.js
+++ b/src/init.js
@@ -24,15 +24,16 @@ export default function init(program) {
 		br();
 
 		const result = await doLogin(program);
-        if (!result) return;
+		if (!result) return;
 
 		const { user, token } = result;
+		const { organisationUuid } = user;
 
 		// load the campaigns
 		const campaignsLoader = ora("Loading your campaigns...").start();
 		try {
 			data.campaigns = await getCampaigns({}, token, {
-				apiUrl: program.api
+				apiUrl: program.api,
 			});
 			campaignsLoader.succeed();
 		} catch (e) {
@@ -45,17 +46,18 @@ export default function init(program) {
 				type: "checkbox",
 				name: "campaigns",
 				message: "Select the campaigns to sync:",
-				choices: data.campaigns.data.map(c => ({
+				choices: data.campaigns.data.map((c) => ({
 					name: `${c.name} (${c.path})`,
 					value: c.uuid,
-					short: c.path
-				}))
-			}
+					short: c.path,
+				})),
+			},
 		]);
 
 		const config = {
 			token,
-			campaigns: campaigns.campaigns
+			campaigns: campaigns.campaigns,
+			organisationUuid,
 		};
 		if (program.api) config.apiUrl = program.api;
 		await saveConfig(config);

--- a/src/init.js
+++ b/src/init.js
@@ -7,6 +7,7 @@ import { login } from "./actions/auth";
 import { getCampaigns } from "./actions/campaigns";
 import { syncStyles, syncComponents } from "./actions/sync";
 import { saveConfig } from "./config";
+import { doLogin } from "./login";
 
 export default function init(program) {
 	program.command("init").action(async (dir, cmd) => {
@@ -23,36 +24,8 @@ export default function init(program) {
 		log(`Log in to your Raisely account to start:`, "white");
 		br();
 
-		// collect login details
-		const credentials = await inquirer.prompt([
-			{
-				type: "input",
-				name: "username",
-				message: "Enter your email address",
-				validate: value =>
-					value.length ? true : "Please enter your email address"
-			},
-			{
-				type: "password",
-				message: "Enter your password",
-				name: "password",
-				validate: value =>
-					value.length ? true : "Please enter a password"
-			}
-		]);
-
-		// log the user in
-		const loginLoader = ora("Logging you in...").start();
 		try {
-			data.user = await login(
-				{
-					...credentials,
-					requestAdminToken: true
-				},
-				{ apiUrl: program.api }
-			);
-			data.token = data.user.token;
-			loginLoader.succeed();
+			const { user, token } = await doLogin();
 		} catch (e) {
 			return error(e, loginLoader);
 		}
@@ -83,7 +56,7 @@ export default function init(program) {
 		]);
 
 		const config = {
-			token: data.token,
+			token,
 			campaigns: campaigns.campaigns
 		};
 		if (program.api) config.apiUrl = program.api;

--- a/src/init.js
+++ b/src/init.js
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import inquirer from "inquirer";
 import ora from "ora";
 
-import { welcome, log, br, error } from "./helpers";
+import { welcome, log, br, error, informUpdate } from "./helpers";
 import { getCampaigns } from "./actions/campaigns";
 import { syncStyles, syncComponents } from "./actions/sync";
 import { saveConfig } from "./config";
@@ -76,5 +76,6 @@ export default function init(program) {
 		br();
 		log("raisely update", "inverse");
 		br();
+		await informUpdate();
 	});
 }

--- a/src/init.js
+++ b/src/init.js
@@ -3,7 +3,6 @@ import inquirer from "inquirer";
 import ora from "ora";
 
 import { welcome, log, br, error } from "./helpers";
-import { login } from "./actions/auth";
 import { getCampaigns } from "./actions/campaigns";
 import { syncStyles, syncComponents } from "./actions/sync";
 import { saveConfig } from "./config";

--- a/src/login.js
+++ b/src/login.js
@@ -1,5 +1,6 @@
 import inquirer from "inquirer";
 import ora from "ora";
+import { login } from "./actions/auth";
 
 import { updateConfig } from "./config";
 
@@ -40,7 +41,7 @@ export async function doLogin(message) {
 	return { user, token };
 }
 
-export default function login(program) {
+export default function loginAction(program) {
 	program.command("login").action(async (dir, cmd) => {
 		try {
 			await doLogin(ora)

--- a/src/login.js
+++ b/src/login.js
@@ -28,14 +28,14 @@ export async function doLogin(message) {
 	// log the user in
 	const loginLoader = ora("Logging you in...").start();
 
-	const user = await login(
+	const loginBody = await login(
 		{
 			...credentials,
 			requestAdminToken: true
 		},
 		{ apiUrl: program.api }
 	);
-	const { token } = data.user;
+	const { token, user } = loginBody;
 	loginLoader.succeed();
 
 	return { user, token };
@@ -44,12 +44,13 @@ export async function doLogin(message) {
 export default function loginAction(program) {
 	program.command("login").action(async (dir, cmd) => {
 		try {
-			await doLogin(ora)
+			const { token, user } = await doLogin(ora)
+			await updateConfig({
+				token,
+				organisationUuid: user.organisationUuid,
+			});
 		} catch (e) {
 			return error(e, loginLoader);
 		}
-		await updateConfig({
-			token,
-		});
 	});
 }

--- a/src/login.js
+++ b/src/login.js
@@ -5,7 +5,6 @@ import { login } from "./actions/auth";
 import { updateConfig } from "./config";
 import { log, error, informUpdate } from "./helpers";
 
-
 export async function doLogin(program, message) {
 	if (message) log(message, "white");
 
@@ -15,16 +14,16 @@ export async function doLogin(program, message) {
 			type: "input",
 			name: "username",
 			message: "Enter your email address",
-			validate: value =>
-				value.length ? true : "Please enter your email address"
+			validate: (value) =>
+				value.length ? true : "Please enter your email address",
 		},
 		{
 			type: "password",
 			message: "Enter your password",
 			name: "password",
-			validate: value =>
-				value.length ? true : "Please enter a password"
-		}
+			validate: (value) =>
+				value.length ? true : "Please enter a password",
+		},
 	]);
 
 	// log the user in
@@ -33,8 +32,8 @@ export async function doLogin(program, message) {
 	try {
 		const loginBody = await login(
 			{
-			...credentials,
-			requestAdminToken: true,
+				...credentials,
+				requestAdminToken: true,
 			},
 			{ apiUrl: program.api }
 		);
@@ -54,7 +53,6 @@ export default function loginAction(program) {
 		const { token, user } = result;
 		await updateConfig({
 			token,
-			organisationUuid: user.organisationUuid,
 		});
 		await informUpdate();
 	});

--- a/src/login.js
+++ b/src/login.js
@@ -1,0 +1,54 @@
+import inquirer from "inquirer";
+import ora from "ora";
+
+import { updateConfig } from "./config";
+
+export async function doLogin(message) {
+	if (message) log(message, "white");
+
+	// collect login details
+	const credentials = await inquirer.prompt([
+		{
+			type: "input",
+			name: "username",
+			message: "Enter your email address",
+			validate: value =>
+				value.length ? true : "Please enter your email address"
+		},
+		{
+			type: "password",
+			message: "Enter your password",
+			name: "password",
+			validate: value =>
+				value.length ? true : "Please enter a password"
+		}
+	]);
+
+	// log the user in
+	const loginLoader = ora("Logging you in...").start();
+
+	const user = await login(
+		{
+			...credentials,
+			requestAdminToken: true
+		},
+		{ apiUrl: program.api }
+	);
+	const { token } = data.user;
+	loginLoader.succeed();
+
+	return { user, token };
+}
+
+export default function login(program) {
+	program.command("login").action(async (dir, cmd) => {
+		try {
+			await doLogin(ora)
+		} catch (e) {
+			return error(e, loginLoader);
+		}
+		await updateConfig({
+			token,
+		});
+	});
+}

--- a/src/start.js
+++ b/src/start.js
@@ -8,11 +8,9 @@ import { welcome, log, br, error, informUpdate } from "./helpers";
 import { updateStyles, buildStyles } from "./actions/campaigns";
 import {
 	updateComponentFile,
-	updateComponentConfig
+	updateComponentConfig,
 } from "./actions/components";
-import {
-	getToken
-} from "./actions/auth";
+import { getToken } from "./actions/auth";
 import { loadConfig } from "./config";
 
 export default function start(program) {
@@ -22,7 +20,7 @@ export default function start(program) {
 		// load config
 		const config = await loadConfig();
 		// Load token, which will prompt a login if the token is expired
-		config.token = await getToken(config, true);
+		config.token = await getToken(program, config, true);
 
 		await informUpdate();
 
@@ -75,7 +73,7 @@ export default function start(program) {
 										path.join(componentsDir, filename),
 										"utf8"
 									)
-								)
+								),
 							},
 							config
 						);
@@ -95,7 +93,7 @@ export default function start(program) {
 										),
 										"utf8"
 									)
-								)
+								),
 							},
 							config
 						);

--- a/src/start.js
+++ b/src/start.js
@@ -18,6 +18,8 @@ export default function start(program) {
 
 		// load config
 		const config = await loadConfig();
+		// Load token, which will prompt a login if the token is expired
+		config.token = await getToken();
 
 		log(`Watching and uploading changes in this directory`, "white");
 		br();
@@ -38,6 +40,7 @@ export default function start(program) {
 			{ encoding: "utf8", recursive: true },
 			async (eventType, filename) => {
 				const loader = ora(`Saving ${filename}`).start();
+				config.token = await getToken();
 
 				await buildStyles(filename, config);
 
@@ -50,6 +53,8 @@ export default function start(program) {
 			{ encoding: "utf8", recursive: true },
 			async (eventType, filename) => {
 				const loader = ora(`Saving ${filename}`).start();
+				config.token = await getToken();
+
 				try {
 					if (filename.includes(".json")) {
 						await updateComponentConfig(

--- a/src/start.js
+++ b/src/start.js
@@ -19,7 +19,7 @@ export default function start(program) {
 		// load config
 		const config = await loadConfig();
 		// Load token, which will prompt a login if the token is expired
-		config.token = await getToken();
+		config.token = await getToken(warnEarly);
 
 		log(`Watching and uploading changes in this directory`, "white");
 		br();

--- a/src/start.js
+++ b/src/start.js
@@ -4,7 +4,7 @@ import fs from "fs";
 import path from "path";
 import glob from "glob-promise";
 
-import { welcome, log, br, error } from "./helpers";
+import { welcome, log, br, error, informUpdate } from "./helpers";
 import { updateStyles, buildStyles } from "./actions/campaigns";
 import {
 	updateComponentFile,

--- a/src/start.js
+++ b/src/start.js
@@ -10,6 +10,9 @@ import {
 	updateComponentFile,
 	updateComponentConfig
 } from "./actions/components";
+import {
+	getToken
+} from "./actions/auth";
 import { loadConfig } from "./config";
 
 export default function start(program) {
@@ -19,7 +22,9 @@ export default function start(program) {
 		// load config
 		const config = await loadConfig();
 		// Load token, which will prompt a login if the token is expired
-		config.token = await getToken(warnEarly);
+		config.token = await getToken(config, true);
+
+		await informUpdate();
 
 		log(`Watching and uploading changes in this directory`, "white");
 		br();
@@ -40,7 +45,6 @@ export default function start(program) {
 			{ encoding: "utf8", recursive: true },
 			async (eventType, filename) => {
 				const loader = ora(`Saving ${filename}`).start();
-				config.token = await getToken();
 
 				await buildStyles(filename, config);
 
@@ -53,7 +57,6 @@ export default function start(program) {
 			{ encoding: "utf8", recursive: true },
 			async (eventType, filename) => {
 				const loader = ora(`Saving ${filename}`).start();
-				config.token = await getToken();
 
 				try {
 					if (filename.includes(".json")) {

--- a/src/update.js
+++ b/src/update.js
@@ -4,6 +4,7 @@ import inquirer from "inquirer";
 import { welcome, log, br, error, informUpdate } from "./helpers";
 import { syncStyles, syncComponents } from "./actions/sync";
 import { loadConfig } from "./config";
+import { getToken } from "./actions/auth";
 
 export default function update(program) {
 	program.command("update").action(async (dir, cmd) => {
@@ -11,7 +12,7 @@ export default function update(program) {
 		let config = await loadConfig();
 
 		// Load token, which will prompt a login if the token is expired
-		config.token = await getToken(warnEarly);
+		await getToken(config, true);
 
 		const data = {};
 

--- a/src/update.js
+++ b/src/update.js
@@ -12,7 +12,7 @@ export default function update(program) {
 		let config = await loadConfig();
 
 		// Load token, which will prompt a login if the token is expired
-		await getToken(config, true);
+		await getToken(program, config, true);
 
 		const data = {};
 
@@ -37,8 +37,8 @@ export default function update(program) {
 			{
 				type: "confirm",
 				name: "confirm",
-				message: "Are you sure you want to continue?"
-			}
+				message: "Are you sure you want to continue?",
+			},
 		]);
 
 		if (!response.confirm) {

--- a/src/update.js
+++ b/src/update.js
@@ -11,7 +11,7 @@ export default function update(program) {
 		let config = await loadConfig();
 
 		// Load token, which will prompt a login if the token is expired
-		config.token = await getToken();
+		config.token = await getToken(warnEarly);
 
 		const data = {};
 

--- a/src/update.js
+++ b/src/update.js
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import inquirer from "inquirer";
 
-import { welcome, log, br, error } from "./helpers";
+import { welcome, log, br, error, informUpdate } from "./helpers";
 import { syncStyles, syncComponents } from "./actions/sync";
 import { loadConfig } from "./config";
 
@@ -58,5 +58,6 @@ export default function update(program) {
 			)} to begin.`,
 			"green"
 		);
+		await informUpdate();
 	});
 }

--- a/src/update.js
+++ b/src/update.js
@@ -10,6 +10,9 @@ export default function update(program) {
 		// load config
 		let config = await loadConfig();
 
+		// Load token, which will prompt a login if the token is expired
+		config.token = await getToken();
+
 		const data = {};
 
 		welcome();


### PR DESCRIPTION
Better handling of token expiry and org switching
Also notes to the user when an updated version of the cli is available.

* Adds a `raisely login` command that can be used to update credentials without having to go through the full init steps
* Automatically checks token expiry and prompts to re-login if it's expired
* When running `raisely start` will prompt to re-login if token expires soon (within 24 hours) so it doesn't go unnoticed and cause confusion during development
* Saves an organisationUuid to the config if one is not present
* Checks `config.organisationUuid` against the current token to fail fast if user account has switched out
* Offers to switch a user back to the correct org if they are switched out

Fixes raisely/raisely#1126