### PR TITLE
Add 2fa support to login

### DIFF
--- a/src/login.js
+++ b/src/login.js
@@ -6,54 +6,76 @@ import { updateConfig } from "./config";
 import { log, error, informUpdate } from "./helpers";
 
 export async function doLogin(program, message) {
-	if (message) log(message, "white");
+  if (message) log(message, "white");
 
-	// collect login details
-	const credentials = await inquirer.prompt([
-		{
-			type: "input",
-			name: "username",
-			message: "Enter your email address",
-			validate: (value) =>
-				value.length ? true : "Please enter your email address",
-		},
-		{
-			type: "password",
-			message: "Enter your password",
-			name: "password",
-			validate: (value) =>
-				value.length ? true : "Please enter a password",
-		},
-	]);
+  // collect login details
+  const credentials = await inquirer.prompt([
+    {
+      type: "input",
+      name: "username",
+      message: "Enter your email address",
+      validate: (value) =>
+        value.length ? true : "Please enter your email address",
+    },
+    {
+      type: "password",
+      message: "Enter your password",
+      name: "password",
+      validate: (value) => (value.length ? true : "Please enter a password"),
+    },
+  ]);
 
-	// log the user in
-	const loginLoader = ora("Logging you in...").start();
+  // log the user in
+  let loginLoader = ora("Logging you in...").start();
 
-	try {
-		const loginBody = await login(
-			{
-				...credentials,
-				requestAdminToken: true,
-			},
-			{ apiUrl: program.api }
-		);
-		const { token, data: user } = loginBody;
-		loginLoader.succeed();
-		return { user, token };
-	} catch (e) {
-		error(e, loginLoader);
-		return false;
-	}
+  try {
+    let loginBody = await login(
+      {
+        ...credentials,
+        requestAdminToken: true,
+      },
+      { apiUrl: program.api }
+    );
+    if (loginBody.data.requiresOtp) {
+      loginLoader.info("Your account requires 2 factor authentication.");
+      const response = await inquirer.prompt([
+        {
+          type: "input",
+          message: "Please provide your one time password",
+          name: "otp",
+          validate: (value) =>
+            value.length ? true : "Please enter a one time password",
+        },
+      ]);
+
+      loginLoader = ora("Logging you in...").start();
+
+      loginBody = await login(
+        {
+          ...credentials,
+          otp: response.otp,
+          requestAdminToken: true,
+        },
+        { apiUrl: program.api }
+      );
+    }
+    const { token, data: user } = loginBody;
+    loginLoader.succeed();
+    return { user, token };
+  } catch (e) {
+    error(e, loginLoader);
+    return false;
+  }
 }
 
 export default function loginAction(program) {
-	program.command("login").action(async (dir, cmd) => {
-		const result = await doLogin(program);
-		if (!result) return;
-		const { token, user } = result;
-		await updateConfig({
-			token,
-		});
-		await informUpdate();
-	});
+  program.command("login").action(async (dir, cmd) => {
+    const result = await doLogin(program);
+    if (!result) return;
+    const { token, user } = result;
+    await updateConfig({
+      token,
+    });
+    await informUpdate();
+  });
 }


### PR DESCRIPTION
@tommckenna and I paired on this one this afternoon, it's actually a fairly small PR to add 2fa support to the CLI.

When you turn 2fa on for your Raisely account and try to connect you'll receive a `requiresOtp` flag on the body, which just requires resubmission of the login API call with the `otp` value present.

This PR catches the presence of the flag, prompts the user for their one time password, and resubmits the login request with the flag added.

I'm PRing against `feature/note-update` as I believe that's the most up to date (beta) branch?

Also apologies for Prettier asserting itself on the file. Happy to change things back if the diff is too hard to read.

Screenshot showing the 2fa flow:
![image](https://user-images.githubusercontent.com/21050732/110064525-5b5e5100-7dc1-11eb-9d0a-ae24928e1df5.png)

Screenshot showing flow without 2fa unchanged:
![image](https://user-images.githubusercontent.com/21050732/110064570-7335d500-7dc1-11eb-8067-66c57c9c05c3.png)
