### PR TITLE
Ensure filenames sent do not include absolute paths (Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.2
+
+- Fix style watching/compiling on Windows
+
 # 1.5.1
 
 - Add support for 2 factor authentication

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@raisely/cli",
-	"version": "1.4.1",
+	"version": "1.5.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@raisely/cli",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"description": "Raisely CLI for local development",
 	"main": "./src/cli.js",
 	"bin": {

--- a/src/actions/campaigns.js
+++ b/src/actions/campaigns.js
@@ -33,21 +33,22 @@ export async function buildStyles(filename, config) {
 	const stylesDir = path.join(process.cwd(), "stylesheets");
 	const filePath = filename.split(path.sep)[0];
 
-	const files = await glob(`${path.join(stylesDir, filePath)}/**/*.scss`);
+  const fullPath = path.join(stylesDir, filePath);
+	const files = await glob(`${fullPath}/**/*.scss`);
 
 	const configFiles = {};
 	for (const file of files) {
 		const fileName = file
-			.replace(`${stylesDir}${path.sep}`, "")
-			.replace(`${filePath}${path.sep}`, "");
+      // `glob` above returns paths with forward slashes only,
+      // so we need to replace potential Windows-style back slashes
+      // before attempting to find and remove the full path.
+      .replace(`${fullPath.replace(/\\/g, "/")}/`, "");
 
 		// continue if this is the main stylesheet
 
 		if (fileName === `${filePath}.scss`) continue;
 
-		configFiles[
-			file.replace(`${stylesDir}/`, "").replace(`${filePath}/`, "")
-		] = fs.readFileSync(file, "utf8");
+		configFiles[fileName] = fs.readFileSync(file, "utf8");
 	}
 
 	await updateStyles(


### PR DESCRIPTION
**What**
This PR ensures that filenames sent to the Raisely api via `buildStyles` don't also include the files' absolute paths when on Windows.

**Why**
It was observed that when running `raisely start` on Windows and making changes to files, the filenames uploaded via `buildStyles` include the files' absolute paths on the User's system. This happens due to our [use of `glob` to create an array of all our files](https://github.com/raisely/cli/blob/5b409b92c691edddc914049d547b353103004c8c/src/actions/campaigns.js#L36), which outputs paths forward-slash-normalized ([relevant Github issue](https://github.com/isaacs/node-glob/issues/419)). 

This in turn causes the first `replace` call both [here](https://github.com/raisely/cli/blob/5b409b92c691edddc914049d547b353103004c8c/src/actions/campaigns.js#L41) and [here](https://github.com/raisely/cli/blob/5b409b92c691edddc914049d547b353103004c8c/src/actions/campaigns.js#L49) to not replace anything, as they rely on `stylesDir`, [which still contains the platform specific path](https://github.com/raisely/cli/blob/5b409b92c691edddc914049d547b353103004c8c/src/actions/campaigns.js#L33) (i.e., with back slashes for Windows). So, for example, instead of sending a value like `0_core/1_variables.scss`, we would send `'C:/Users/username/raisely/stylesheets/0_core/1_variables.scss'`.

This issue then manifests itself when syncing locally / running `raisely update`. As the [filenames received from `campaign.data.config.css.files`](https://github.com/raisely/cli/blob/5b409b92c691edddc914049d547b353103004c8c/src/actions/sync.js#L34) will all actually be absolute paths, resulting in an error like the following when [trying to create the directory](https://github.com/raisely/cli/blob/5b409b92c691edddc914049d547b353103004c8c/src/actions/sync.js#L45) for the given filename:

```bash
× ENOENT: no such file or directory, mkdir 'C:\Users\tmns\raisely\stylesheets\campaign\C:\Users\tmns\raisely\stylesheets\0_core'
```

**How**
The proposed fix is to also run `replace` on the full path, swapping all potential forward slashes with back slashes, before trying to remove the path as normal:

```js
const fileName = path.replace(`${fullPath.replace(/\\/g, '/')}/`, "");
```

@chrisjensen  also suggested using `path.normalize`; however, if we do that, I think we then need to use `path.sep` in places where we're currently using `/` ([for example in `sync.js`](https://github.com/raisely/cli/blob/3fe2a9542234084e553d9cd6a78cc119dd1ea716/src/actions/sync.js#L8)). I see that we actually did do that before but then that [change was reverted](https://github.com/raisely/cli/commit/3fe2a9542234084e553d9cd6a78cc119dd1ea716); so, I'm not too keen on adding that back.. but someone with more context could probably make the right call here!

Another potential challenge with `path.normalize` is that a user would again face update issues when switching between Windows / non-Windows machines, as one machine would push with a platform-specific path and then the other would try to parse it with its own `path.sep`. For example, if on Windows `0_core\1_variables.scss` was pushed, on Mac / Linux instead of the folder `0_core` with the file `1_variables.scss` being created, a file with the name `0_core\1_variables.scss` would be created. Having said all that, I imagine this is also an edge case.

**Testing**
I've tested the changes on Win11 and Mac. However, folks with more knowledge of the code / cli should definitely test it as well, as it's entirely possible I'm not covering all cases.

To reproduce the error on Windows:
1. Run `raisely init` and pull down all relevant files.
2. Run `raisely start` and make a change to a stylesheet.
3. Run `raisely update`; at this point you should get an error similar to that shown above.