### PR TITLE
Fixed error message for failed stylesheet uploads and bumped version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@raisely/cli",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"description": "Raisely CLI for local development",
 	"main": "./src/cli.js",
 	"type": "module",

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -63,7 +63,8 @@ export default async function deploy() {
 				`${campaign.data.path}${path.sep}${campaign.data.path}.scss`
 			);
 		} catch (e) {
-			console.error(e.stack);
+			br();
+			console.error(e);
 			process.exit(1);
 		}
 


### PR DESCRIPTION
**🔍 What should we check?**
- Stylesheet uploads that fail return the Raisely API failure message.

**🍒  What have you changed?**
- Changed the error message to provide the full error.

**⚡ Which issue does this solve?**
- No error is returned when the API fails to upload stylesheets through `e.stack`

**🥜 How can this be tested or verified?**

**🖼️ Expected results**
![001161](https://user-images.githubusercontent.com/33829848/194195522-9debbe25-1810-46ba-a62e-2d77b9c3d9c2.png)

## For Reviewers
The person reviewing the pull request must answer:

- [ ] If the author is new to this part of the codebase, has this code been tested and any edge cases by someone familiar with this and how it should work?
- [ ] Do you understand exactly what this code is and can a future developer understand it?
- [ ] Is the code well documented?

### Front End

- [ ] Is there suitable inline descriptions, help text or warnings so most people can use this feature without asking for help?

### Security & Testing

- [ ] Is there appropriate testing for this (API route tests, critical pathway test in Cypress if it impacts core functions)?
- [ ] Are all untrusted inputs (eg to SQL, external HTTP requests, embedded HTML) [properly escaped](https://www.notion.so/raisely/Validation-Cleaning-Input-85e1183b85e94280bb01a70bd38ed8fb)
- [ ] Does it use [standard libraries/helpers for crypto, security and identity](https://www.notion.so/raisely/193c84cf56be4b69aa7f012e8e6c74a7?v=0ffe2232070a421eafd8ec300f837a5e)

