### PR TITLE
Update MFA handling as api now throws error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@raisely/cli",
-	"version": "1.8.0",
+	"version": "1.8.1",
 	"description": "Raisely CLI for local development",
 	"main": "./src/cli.js",
 	"type": "module",

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -69,9 +69,9 @@ export default async function api(options) {
 
 				if (responseIsJSON && formatted) {
 					// if subcode, add this to error
-					const subcode = _.get(formatted, 'errors[0].subcode')
+					const subcode = _.get(formatted, 'errors[0].subcode');
 					if (subcode) {
-						error.subcode = subcode
+						error.subcode = subcode;
 					}
 				}
 
@@ -83,7 +83,7 @@ export default async function api(options) {
 
 			// Handle MFA error
 			if (e.subcode && e.subcode.startsWith('MFA required')) {
-				throw e
+				throw e;
 			}
 
 			// Skip hard failures, except a timeout

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -127,3 +127,7 @@ export function error(e, loader) {
 		console.log(`${chalk.bgRed('Error:')} ${chalk.red(message)}`);
 	}
 }
+
+export function requiresMfa(e) {
+	return e.subcode && e.subcode.startsWith('MFA required')
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -129,5 +129,5 @@ export function error(e, loader) {
 }
 
 export function requiresMfa(e) {
-	return e.subcode && e.subcode.startsWith('MFA required')
+	return e.subcode && e.subcode.startsWith('MFA required');
 }

--- a/src/login.js
+++ b/src/login.js
@@ -4,7 +4,7 @@ import ora from 'ora';
 import { login } from './actions/auth.js';
 
 import { updateConfig } from './config.js';
-import { log, error, informUpdate } from './helpers.js';
+import { log, error, informUpdate, requiresMfa } from './helpers.js';
 
 export async function doLogin(message) {
 	if (message) log(message, 'white');
@@ -35,35 +35,50 @@ export async function doLogin(message) {
 			...credentials,
 			requestAdminToken: true,
 		});
-		if (loginBody.data.requiresOtp) {
-			loginLoader.info('Your account requires 2 factor authentication.');
-			const response = await inquirer.prompt([
-				{
-					type: 'input',
-					message: 'Please provide your one time password',
-					name: 'otp',
-					validate: (value) =>
-						value.length
-							? true
-							: 'Please enter a one time password',
-				},
-			]);
-
-			loginLoader = ora('Logging you in...').start();
-
-			loginBody = await login({
-				...credentials,
-				otp: response.otp,
-				requestAdminToken: true,
-			});
+		return loginSucceed(loginLoader, loginBody)
+	} catch (e) {
+		if (requiresMfa(e)) {
+			return await loginWith2FA(loginLoader, credentials)
+		} else {
+			error(e, loginLoader);
+			return false;
 		}
-		const { token, data: user } = loginBody;
-		loginLoader.succeed();
-		return { user, token };
+	}
+}
+
+async function loginWith2FA(loginLoader, credentials) {
+	loginLoader.info('Your account requires 2 factor authentication.');
+	try {
+		const response = await inquirer.prompt([
+			{
+				type: 'input',
+				message: 'Please provide your one time password',
+				name: 'otp',
+				validate: (value) =>
+					value.length
+						? true
+						: 'Please enter a one time password',
+			},
+		]);
+
+		loginLoader.info('Logging you in...');
+
+		const loginBody = await login({
+			...credentials,
+			otp: response.otp,
+			requestAdminToken: true,
+		});
+		return loginSucceed(loginLoader, loginBody)
 	} catch (e) {
 		error(e, loginLoader);
-		return false;
+		return false
 	}
+}
+
+async function loginSucceed(loginLoader, loginBody) {
+	const { token, data: user } = loginBody;
+	loginLoader.succeed();
+	return { user, token };
 }
 
 export default async function loginAction() {

--- a/src/login.js
+++ b/src/login.js
@@ -35,10 +35,10 @@ export async function doLogin(message) {
 			...credentials,
 			requestAdminToken: true,
 		});
-		return loginSucceed(loginLoader, loginBody)
+		return loginSucceed(loginLoader, loginBody);
 	} catch (e) {
 		if (requiresMfa(e)) {
-			return await loginWith2FA(loginLoader, credentials)
+			return await loginWith2FA(loginLoader, credentials);
 		} else {
 			error(e, loginLoader);
 			return false;
@@ -68,10 +68,10 @@ async function loginWith2FA(loginLoader, credentials) {
 			otp: response.otp,
 			requestAdminToken: true,
 		});
-		return loginSucceed(loginLoader, loginBody)
+		return loginSucceed(loginLoader, loginBody);
 	} catch (e) {
 		error(e, loginLoader);
-		return false
+		return false;
 	}
 }
 


### PR DESCRIPTION
**🔍 What should we check?**
- Login with and without MFA on works as expected

**🍒 What have you changed?**
- Handle MFA errors so that the login flow can continue as expected

**⚡ Which issue does this solve?**
This fixes an issue where users with MFA cannot login to the CLI, as the Raisely api now throws an error to indicate an MFA code is required. 

If you try and run `master` branch now, and your user has MFA, the error will prevent any action and does not prompt for MFA code.

To test, you can run this branch locally and test the package:
- check out this branch
- point RAISELY_API_URL to the development api
- ensure that your test user has an authy enrolment
- then run `npm install <path to cli> -g`
- then `raisely init` and confirmed that the package seemed to be working:

**Dev example:**

![Screenshot 2023-10-30 at 3 49 02 pm](https://github.com/raisely/cli/assets/25245618/499a9191-d30d-4ddb-8891-779e9959759e)


