### PR TITLE
Update local.js - updated rasiely URL on target

### DIFF
--- a/src/local.js
+++ b/src/local.js
@@ -75,7 +75,7 @@ export default async function start() {
 	// determine proxy target
 	const target = config.proxyUrl
 		? config.proxyUrl.replace('https://', `https://${campaign.path}.`)
-		: `https://${campaign.path}.raisely.com`;
+		: `https://${campaign.path}.raiselysite.com`;
 
 	const app = express();
 


### PR DESCRIPTION
Target was pointing to "https://${campaign.path}.raisely.com" which returned a redirection to "https://${campaign.path}.raiselysite.com" so the interception didn't work. 
That line of code was changed so it now points directly to https://${campaign.path}.raiselysite.com avoiding the redirection.