### PR TITLE
SIR-1519 - cli v2 switch readers and writers to v2 layout

### DIFF
--- a/src/actions/campaigns.js
+++ b/src/actions/campaigns.js
@@ -1,7 +1,7 @@
 import glob from 'glob-promise';
-import path from 'path';
 import fs from 'fs';
 import api from './api.js';
+import { resolveCampaignPaths } from './layout.js';
 
 export async function getCampaigns({ all = false } = {}) {
 	if (!all) {
@@ -52,39 +52,34 @@ export async function getBaseStyles({ uuid }) {
 	});
 }
 
-export async function fetchStyles({ campaign, filename }) {
-	const stylesDir = path.join(process.cwd(), 'stylesheets');
-	const filePath = campaign || filename.split(path.sep)[0];
+export async function fetchStyles({ campaign }) {
+	const { stylesheetsDir, mainScss } = resolveCampaignPaths(
+		process.cwd(),
+		campaign
+	);
 
-	const fullPath = path.join(stylesDir, filePath);
-	const files = await glob(`${fullPath}/**/*.scss`);
+	const files = await glob(`${stylesheetsDir}/**/*.scss`);
 
 	const configFiles = {};
 	for (const file of files) {
 		const fileName = file
-			// `glob` above returns paths with forward slashes only,
-			// so we need to replace potential Windows-style back slashes
-			// before attempting to find and remove the full path.
-			.replace(`${fullPath.replace(/\\/g, '/')}/`, '');
+			// `glob` returns paths with forward slashes only,
+			// so normalise Windows-style back slashes before stripping the prefix.
+			.replace(`${stylesheetsDir.replace(/\\/g, '/')}/`, '');
 
-		// continue if this is the main stylesheet
-
-		if (fileName === `${filePath}.scss`) continue;
+		if (fileName === 'main.scss') continue;
 
 		configFiles[fileName] = fs.readFileSync(file, 'utf8');
 	}
 
 	return {
 		configFiles,
-		css: fs.readFileSync(
-			path.join(stylesDir, filePath, `${filePath}.scss`),
-			'utf8'
-		),
+		css: fs.readFileSync(mainScss, 'utf8'),
 	};
 }
 
-export async function processStyles({ campaign, config }) {
-	const { configFiles, css } = await fetchStyles({ campaign, config });
+export async function processStyles({ campaign }) {
+	const { configFiles, css } = await fetchStyles({ campaign });
 
 	let output = css;
 
@@ -95,18 +90,13 @@ export async function processStyles({ campaign, config }) {
 	return output;
 }
 
-export async function uploadStyles(filename) {
-	// The filename will contain the relative campaign path (needs to be posix)
-	const [campaignPath] = filename.split(path.sep);
-
+export async function uploadStyles(campaignPath) {
 	const campaign = await api({
 		path: `/campaigns/${campaignPath}?private=1`,
 		method: 'GET',
 	});
 
-	const { configFiles, css } = await fetchStyles({
-		filename,
-	});
+	const { configFiles, css } = await fetchStyles({ campaign: campaignPath });
 
 	const data = Object.assign({}, campaign.data.config.css, {
 		files: configFiles,

--- a/src/actions/pages.js
+++ b/src/actions/pages.js
@@ -21,19 +21,19 @@ export function compilePageBody(page) {
  * @param {{ campaignUuid?: string }} [opts] If campaignUuid is set, only pages belonging to that campaign are compiled.
  */
 export async function compileAllLocalPages({ campaignUuid } = {}) {
-	const pagesDir = path.join(process.cwd(), 'pages');
-	if (!fs.existsSync(pagesDir)) {
+	const campaignsDir = path.join(process.cwd(), 'campaigns');
+	if (!fs.existsSync(campaignsDir)) {
 		return {};
 	}
 
-	const files = await glob('**/*.json', {
-		cwd: pagesDir,
+	const files = await glob('campaigns/*/pages/**/*.json', {
+		cwd: process.cwd(),
 		nodir: true,
 	});
 
 	const map = {};
 	for (const file of files) {
-		const fullPath = path.join(pagesDir, file);
+		const fullPath = path.join(process.cwd(), file);
 		const raw = fs.readFileSync(fullPath, 'utf8');
 		let page;
 		try {

--- a/src/actions/sync.js
+++ b/src/actions/sync.js
@@ -5,14 +5,10 @@ import fs from 'fs';
 import api from './api.js';
 import { error } from '../helpers.js';
 import { loadConfig } from '../config.js';
+import { resolveCampaignPaths } from './layout.js';
 
 export async function syncStyles() {
 	const config = await loadConfig();
-
-	const directory = path.join(process.cwd(), 'stylesheets');
-	if (!fs.existsSync(directory)) {
-		fs.mkdirSync(directory);
-	}
 
 	const loader = ora('Downloading campaign stylesheets...').start();
 	try {
@@ -21,18 +17,19 @@ export async function syncStyles() {
 				path: `/campaigns/${uuid}?private=1`,
 			});
 
-			const campaignDir = path.join(directory, campaign.data.path);
+			const { stylesheetsDir, mainScss } = resolveCampaignPaths(
+				process.cwd(),
+				campaign.data.path
+			);
 
-			if (!fs.existsSync(campaignDir)) {
-				fs.mkdirSync(campaignDir);
+			if (!fs.existsSync(stylesheetsDir)) {
+				fs.mkdirSync(stylesheetsDir, { recursive: true });
 			}
 
 			if (campaign.data.config.css.files) {
 				const files = campaign.data.config.css.files;
 
-				for (const file of Object.keys(
-					campaign.data.config.css.files
-				)) {
+				for (const file of Object.keys(files)) {
 					const fileFolder = file
 						.split('/')
 						.filter((f) => !f.includes('.'));
@@ -40,7 +37,7 @@ export async function syncStyles() {
 						.split('/')
 						.filter((f) => f.includes('.'))
 						.join('');
-					const fileDir = path.join(campaignDir, ...fileFolder);
+					const fileDir = path.join(stylesheetsDir, ...fileFolder);
 
 					if (!fs.existsSync(fileDir)) {
 						fs.mkdirSync(fileDir, { recursive: true });
@@ -50,10 +47,7 @@ export async function syncStyles() {
 				}
 			}
 
-			fs.writeFileSync(
-				path.join(campaignDir, `${campaign.data.path}.scss`),
-				campaign.data.config.css.custom_css
-			);
+			fs.writeFileSync(mainScss, campaign.data.config.css.custom_css);
 		}
 		loader.succeed();
 	} catch (e) {
@@ -73,11 +67,6 @@ function pageFileName(page) {
 export async function syncPages() {
 	const config = await loadConfig();
 
-	const directory = path.join(process.cwd(), 'pages');
-	if (!fs.existsSync(directory)) {
-		fs.mkdirSync(directory);
-	}
-
 	const loader = ora('Downloading campaign pages...').start();
 	try {
 		for (const uuid of config.campaigns) {
@@ -85,9 +74,13 @@ export async function syncPages() {
 				path: `/campaigns/${uuid}?private=1`,
 			});
 
-			const campaignPagesDir = path.join(directory, campaign.data.path);
-			if (!fs.existsSync(campaignPagesDir)) {
-				fs.mkdirSync(campaignPagesDir, { recursive: true });
+			const { pagesDir } = resolveCampaignPaths(
+				process.cwd(),
+				campaign.data.path
+			);
+
+			if (!fs.existsSync(pagesDir)) {
+				fs.mkdirSync(pagesDir, { recursive: true });
 			}
 
 			const pages = await api({
@@ -114,7 +107,7 @@ export async function syncPages() {
 				};
 
 				fs.writeFileSync(
-					path.join(campaignPagesDir, pageFileName(page)),
+					path.join(pagesDir, pageFileName(page)),
 					JSON.stringify(out, null, 4)
 				);
 			}

--- a/src/credentials.js
+++ b/src/credentials.js
@@ -11,7 +11,8 @@ export const KEYCHAIN_SERVICE = '@raisely/cli';
 export const SESSION_DIR = path.join(os.homedir(), '.raisely');
 export const SESSION_FILE = path.join(SESSION_DIR, 'session.json');
 
-export const OAUTH_CLIENT_ID_PLACEHOLDER ='a4151d50-3f65-11f1-8a2b-25aca0e28fce';
+export const OAUTH_CLIENT_ID_PLACEHOLDER =
+	'a4151d50-3f65-11f1-8a2b-25aca0e28fce';
 
 const REFRESH_WINDOW_MS = 5 * 60 * 1000;
 
@@ -42,7 +43,9 @@ export function getHost(apiUrl) {
 
 export function getAccountKey({ apiUrl, organisationUuid }) {
 	if (!apiUrl || !organisationUuid) {
-		throw new Error('apiUrl and organisationUuid are required for keychain key');
+		throw new Error(
+			'apiUrl and organisationUuid are required for keychain key'
+		);
 	}
 	return `${getHost(apiUrl)}:${organisationUuid}`;
 }
@@ -66,11 +69,7 @@ export function writeSessionPointer({ host, organisationUuid }) {
 
 export function clearSessionPointerIfMatches(host, organisationUuid) {
 	const s = readSessionPointer();
-	if (
-		s &&
-		s.host === host &&
-		s.organisationUuid === organisationUuid
-	) {
+	if (s && s.host === host && s.organisationUuid === organisationUuid) {
 		try {
 			fs.unlinkSync(SESSION_FILE);
 		} catch {
@@ -111,7 +110,8 @@ export function getKeychainEntry(accountKey) {
  */
 function rethrowFetchFailure(fetchUrl, e) {
 	const c = e && typeof e === 'object' && 'cause' in e ? e.cause : null;
-	const detail = c && typeof c === 'object' && 'message' in c ? c.message : e.message;
+	const detail =
+		c && typeof c === 'object' && 'message' in c ? c.message : e.message;
 	const code = c && typeof c === 'object' && 'code' in c ? c.code : '';
 	const parts = [`Request to ${fetchUrl} failed: ${detail}`];
 	if (code) parts.push(`(${code})`);
@@ -153,7 +153,9 @@ export async function oauthRequestToken(apiUrl, body) {
 		json = JSON.parse(text);
 	} catch {
 		const err = new Error(
-			`Token endpoint returned non-JSON (${response.status}): ${text.slice(0, 200)}`
+			`Token endpoint returned non-JSON (${
+				response.status
+			}): ${text.slice(0, 200)}`
 		);
 		err.status = response.status;
 		throw err;
@@ -161,7 +163,10 @@ export async function oauthRequestToken(apiUrl, body) {
 
 	if (!response.ok) {
 		const err = new Error(
-			json.error_description || json.error || response.statusText || 'Token request failed'
+			json.error_description ||
+				json.error ||
+				response.statusText ||
+				'Token request failed'
 		);
 		err.code = json.error;
 		err.status = response.status;
@@ -185,7 +190,10 @@ export async function saveCredentials({
 	refresh_token,
 	expires_in,
 }) {
-	const accountKey = getAccountKey({ apiUrl, organisationUuid: organisation_uuid });
+	const accountKey = getAccountKey({
+		apiUrl,
+		organisationUuid: organisation_uuid,
+	});
 	const expires_at = Date.now() + expires_in * 1000;
 	const payload = {
 		access_token,
@@ -250,7 +258,9 @@ export async function refreshAccessToken(accountKey, apiUrl) {
 		throw new NotAuthenticatedError('Stored credentials are corrupted');
 	}
 	if (!stored.refresh_token) {
-		throw new NotAuthenticatedError('No refresh token stored; run `raisely login`');
+		throw new NotAuthenticatedError(
+			'No refresh token stored; run `raisely login`'
+		);
 	}
 
 	const clientId = getOAuthClientId();
@@ -278,7 +288,10 @@ export async function refreshAccessToken(accountKey, apiUrl) {
 				e.status === 401 ||
 				e.status === 400
 			) {
-				clearCredentials({ apiUrl, organisationUuid: stored.organisation_uuid });
+				clearCredentials({
+					apiUrl,
+					organisationUuid: stored.organisation_uuid,
+				});
 			}
 			throw e;
 		}
@@ -338,7 +351,9 @@ export async function getCredentials({ allowPrompt = true } = {}) {
 			try {
 				stored = JSON.parse(raw);
 			} catch {
-				throw new NotAuthenticatedError('Stored credentials are corrupted');
+				throw new NotAuthenticatedError(
+					'Stored credentials are corrupted'
+				);
 			}
 			if (needsProactiveRefresh(stored)) {
 				try {

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -60,9 +60,7 @@ export default async function deploy(options = {}) {
 		const campaign = await getCampaign({ uuid: campaignUuid });
 
 		try {
-			await uploadStyles(
-				`${campaign.data.path}${path.sep}${campaign.data.path}.scss`
-			);
+			await uploadStyles(campaign.data.path);
 		} catch (e) {
 			br();
 			console.error(e);
@@ -113,7 +111,7 @@ export default async function deploy(options = {}) {
 	}
 
 	// upload pages
-	const pageFiles = await glob('pages/**/*.json', {
+	const pageFiles = await glob('campaigns/*/pages/**/*.json', {
 		cwd: process.cwd(),
 	});
 

--- a/src/start.js
+++ b/src/start.js
@@ -45,16 +45,20 @@ export default async function start() {
 	log(`Use CTRL + C to stop`, 'white');
 
 	// watch folders
-	const stylesDir = path.join(process.cwd(), 'stylesheets');
+	const campaignsDir = path.join(process.cwd(), 'campaigns');
 	const componentsDir = path.join(process.cwd(), 'components');
 	watch(
-		stylesDir,
+		campaignsDir,
 		{ encoding: 'utf8', recursive: true },
 		async (eventType, filenameRaw) => {
-			const filename = path.relative(stylesDir, filenameRaw);
-			const loader = ora(`Saving ${filename}`).start();
+			const relative = path.relative(campaignsDir, filenameRaw);
+			const parts = relative.split(path.sep);
+			// Only handle stylesheet changes: <campaign-path>/stylesheets/...
+			if (parts.length < 3 || parts[1] !== 'stylesheets') return;
+			const campaignPath = parts[0];
+			const loader = ora(`Saving ${relative}`).start();
 
-			await uploadStyles(filename);
+			await uploadStyles(campaignPath);
 
 			loader.succeed();
 		}

--- a/tests/campaigns.test.js
+++ b/tests/campaigns.test.js
@@ -1,0 +1,252 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import glob from 'glob-promise';
+
+import { fetchStyles, processStyles } from '../src/actions/campaigns.js';
+import { compileAllLocalPages } from '../src/actions/pages.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.join(__dirname, 'fixtures');
+const originalCwd = process.cwd();
+
+/**
+ * Run fn() with process.cwd() pointing at fixtures/<name>, then restore.
+ */
+function withFixture(fixtureName, fn) {
+	return async () => {
+		process.chdir(path.join(fixturesDir, fixtureName));
+		try {
+			await fn();
+		} finally {
+			process.chdir(originalCwd);
+		}
+	};
+}
+
+// ---------------------------------------------------------------------------
+// fetchStyles
+// ---------------------------------------------------------------------------
+
+describe('fetchStyles – v2 layout', () => {
+	test(
+		'reads main.scss as css for my-campaign',
+		withFixture('v2', async () => {
+			const result = await fetchStyles({ campaign: 'my-campaign' });
+			assert.ok(
+				result.css.includes('.raisely-campaign'),
+				'css should contain .raisely-campaign rule'
+			);
+		})
+	);
+
+	test(
+		'excludes main.scss from configFiles',
+		withFixture('v2', async () => {
+			const result = await fetchStyles({ campaign: 'my-campaign' });
+			assert.ok(
+				!Object.prototype.hasOwnProperty.call(result.configFiles, 'main.scss'),
+				'main.scss should not appear in configFiles'
+			);
+		})
+	);
+
+	test(
+		'includes _variables.scss in configFiles',
+		withFixture('v2', async () => {
+			const result = await fetchStyles({ campaign: 'my-campaign' });
+			assert.ok(
+				Object.prototype.hasOwnProperty.call(
+					result.configFiles,
+					'_variables.scss'
+				),
+				'_variables.scss should be present in configFiles'
+			);
+			assert.ok(
+				result.configFiles['_variables.scss'].includes('$primary'),
+				'_variables.scss content should include $primary'
+			);
+		})
+	);
+
+	test(
+		'returns empty configFiles when campaign has no partials',
+		withFixture('v2', async () => {
+			const result = await fetchStyles({ campaign: 'spring_2026' });
+			assert.deepEqual(
+				result.configFiles,
+				{},
+				'spring_2026 has no partials'
+			);
+		})
+	);
+
+	test(
+		'reads each campaign independently in a multi-campaign repo',
+		withFixture('v2-multi', async () => {
+			const one = await fetchStyles({ campaign: 'campaign-one' });
+			const two = await fetchStyles({ campaign: 'campaign-two' });
+			assert.ok(
+				one.css.includes('#e63946'),
+				'campaign-one css should include #e63946'
+			);
+			assert.ok(
+				two.css.includes('#457b9d'),
+				'campaign-two css should include #457b9d'
+			);
+			assert.notEqual(
+				one.css,
+				two.css,
+				'each campaign should have its own distinct css'
+			);
+		})
+	);
+
+	test(
+		'campaign-two has no partials in multi-campaign repo',
+		withFixture('v2-multi', async () => {
+			const result = await fetchStyles({ campaign: 'campaign-two' });
+			assert.deepEqual(result.configFiles, {});
+		})
+	);
+});
+
+// ---------------------------------------------------------------------------
+// processStyles
+// ---------------------------------------------------------------------------
+
+describe('processStyles – v2 layout', () => {
+	test(
+		'concatenates main.scss and partials for my-campaign',
+		withFixture('v2', async () => {
+			const output = await processStyles({ campaign: 'my-campaign' });
+			assert.ok(
+				output.includes('.raisely-campaign'),
+				'output should include main scss rule'
+			);
+			assert.ok(
+				output.includes('$primary'),
+				'output should include content from _variables.scss partial'
+			);
+		})
+	);
+
+	test(
+		'returns only main.scss content when no partials exist',
+		withFixture('v2', async () => {
+			const output = await processStyles({ campaign: 'spring_2026' });
+			assert.ok(output.includes('.raisely-campaign'));
+			assert.ok(output.includes('#0b7a75'));
+		})
+	);
+
+	test(
+		'returns independent output for each campaign in multi-campaign repo',
+		withFixture('v2-multi', async () => {
+			const one = await processStyles({ campaign: 'campaign-one' });
+			const two = await processStyles({ campaign: 'campaign-two' });
+			assert.notEqual(one, two);
+		})
+	);
+});
+
+// ---------------------------------------------------------------------------
+// compileAllLocalPages
+// ---------------------------------------------------------------------------
+
+describe('compileAllLocalPages – v2 layout', () => {
+	test(
+		'compiles pages from campaigns/*/pages/**/*.json in single-campaign repo',
+		withFixture('v2', async () => {
+			const map = await compileAllLocalPages();
+			assert.ok(
+				Object.prototype.hasOwnProperty.call(map, 'page-uuid-001'),
+				'map should include page-uuid-001 from my-campaign'
+			);
+			assert.ok(
+				Object.prototype.hasOwnProperty.call(map, 'page-uuid-special-v2'),
+				'map should include page-uuid-special-v2 from spring_2026'
+			);
+		})
+	);
+
+	test(
+		'filters pages by campaignUuid when provided',
+		withFixture('v2', async () => {
+			const map = await compileAllLocalPages({
+				campaignUuid: 'campaign-uuid-my-campaign',
+			});
+			assert.ok(
+				Object.prototype.hasOwnProperty.call(map, 'page-uuid-001')
+			);
+			assert.ok(
+				!Object.prototype.hasOwnProperty.call(map, 'page-uuid-special-v2'),
+				'page from a different campaign should be excluded'
+			);
+		})
+	);
+
+	test(
+		'compiles pages from all campaigns in a multi-campaign repo',
+		withFixture('v2-multi', async () => {
+			const map = await compileAllLocalPages();
+			assert.ok(
+				Object.prototype.hasOwnProperty.call(map, 'page-uuid-001'),
+				'map should include page from campaign-one'
+			);
+			assert.ok(
+				Object.prototype.hasOwnProperty.call(map, 'page-uuid-002'),
+				'map should include page from campaign-two'
+			);
+		})
+	);
+
+	test(
+		'returns empty map when campaigns/ directory does not exist',
+		withFixture('legacy', async () => {
+			const map = await compileAllLocalPages();
+			assert.deepEqual(map, {});
+		})
+	);
+});
+
+// ---------------------------------------------------------------------------
+// deploy-time page glob
+// ---------------------------------------------------------------------------
+
+describe('deploy-time page glob – campaigns/*/pages/**/*.json', () => {
+	test('finds all page files in a single-campaign v2 repo', async () => {
+		const fixturePath = path.join(fixturesDir, 'v2');
+		const files = await glob('campaigns/*/pages/**/*.json', {
+			cwd: fixturePath,
+		});
+		assert.equal(files.length, 2, 'should find home.json for both campaigns');
+		assert.ok(
+			files.some((f) => f.includes('my-campaign')),
+			'should find my-campaign page'
+		);
+		assert.ok(
+			files.some((f) => f.includes('spring_2026')),
+			'should find spring_2026 page'
+		);
+	});
+
+	test('finds pages from all campaigns in a multi-campaign v2 repo', async () => {
+		const fixturePath = path.join(fixturesDir, 'v2-multi');
+		const files = await glob('campaigns/*/pages/**/*.json', {
+			cwd: fixturePath,
+		});
+		assert.equal(files.length, 2);
+		assert.ok(files.some((f) => f.includes('campaign-one')));
+		assert.ok(files.some((f) => f.includes('campaign-two')));
+	});
+
+	test('returns no files for a legacy repo', async () => {
+		const fixturePath = path.join(fixturesDir, 'legacy');
+		const files = await glob('campaigns/*/pages/**/*.json', {
+			cwd: fixturePath,
+		});
+		assert.equal(files.length, 0);
+	});
+});

--- a/tests/fixtures/v2-multi/campaigns/campaign-one/pages/home.json
+++ b/tests/fixtures/v2-multi/campaigns/campaign-one/pages/home.json
@@ -3,5 +3,7 @@
     "path": "/",
     "title": "Home",
     "name": "home",
-    "status": "published"
+    "status": "published",
+    "body": [],
+    "campaignUuid": "campaign-uuid-one"
 }

--- a/tests/fixtures/v2-multi/campaigns/campaign-two/pages/home.json
+++ b/tests/fixtures/v2-multi/campaigns/campaign-two/pages/home.json
@@ -3,5 +3,7 @@
     "path": "/",
     "title": "Home",
     "name": "home",
-    "status": "published"
+    "status": "published",
+    "body": [],
+    "campaignUuid": "campaign-uuid-two"
 }

--- a/tests/fixtures/v2/campaigns/my-campaign/pages/home.json
+++ b/tests/fixtures/v2/campaigns/my-campaign/pages/home.json
@@ -3,5 +3,7 @@
     "path": "/",
     "title": "Home",
     "name": "home",
-    "status": "published"
+    "status": "published",
+    "body": [],
+    "campaignUuid": "campaign-uuid-my-campaign"
 }

--- a/tests/fixtures/v2/campaigns/spring_2026/pages/home.json
+++ b/tests/fixtures/v2/campaigns/spring_2026/pages/home.json
@@ -3,5 +3,7 @@
     "path": "/",
     "title": "Spring Campaign Home",
     "name": "home",
-    "status": "published"
+    "status": "published",
+    "body": [],
+    "campaignUuid": "campaign-uuid-spring-2026"
 }


### PR DESCRIPTION
## Summary

- Switches all readers and writers to the v2 layout so every command that touches per-campaign content goes through `resolveCampaignPaths` instead of computing paths inline.
- `raisely init` and `raisely update` write stylesheets to `campaigns/<path>/stylesheets/main.scss` and pages to `campaigns/<path>/pages/`.
- `raisely deploy` and `raisely start` read from the same v2 paths; `raisely local` inherits the change through `processStyles`.
- Adds 16 fixture-based tests covering `fetchStyles`, `processStyles`, `compileAllLocalPages`, and the deploy-time page glob — single-campaign and multi-campaign both covered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes filesystem path resolution for styles/pages across `sync`, `deploy`, and `start`, which could break existing repos or miss uploads if the layout/globs are wrong. No auth/PII/payment logic changes, and new fixture-based tests reduce regression risk.
> 
> **Overview**
> Moves all per-campaign stylesheet/page reads and writes to the v2 repo layout under `campaigns/<campaignPath>/...` by routing path construction through `resolveCampaignPaths`.
> 
> Stylesheet handling now treats `campaigns/<campaignPath>/stylesheets/main.scss` as the main file (excluding it from partial uploads), and `deploy`/`start`/`sync` are updated accordingly (including watching `campaigns/` and uploading by `campaignPath`). Page compilation and deploy-time discovery now glob `campaigns/*/pages/**/*.json`.
> 
> Adds fixture-based tests covering `fetchStyles`, `processStyles`, `compileAllLocalPages`, and the deploy page glob for single- and multi-campaign v2 repos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dd16108ddef1c63fb3dcd0478a5481a407cb4d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->