### PR TITLE
SIR-1520 - cli v2 last good css cache and scss error tolerance

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -7,6 +7,7 @@ import {
 	refreshCredentialsForCurrentContext,
 	NotAuthenticatedError,
 } from '../credentials.js';
+import { sleep } from './sleep.js';
 
 const devHttpsAgent = new https.Agent({
 	rejectUnauthorized: false,
@@ -16,10 +17,6 @@ function getResponseContentType(response) {
 	const rawResponseContentType = response.headers.get('Content-Type');
 	const [contentType] = rawResponseContentType.split(';');
 	return contentType;
-}
-
-function sleep(ms) {
-	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export default async function api(options) {

--- a/src/actions/sleep.js
+++ b/src/actions/sleep.js
@@ -1,0 +1,3 @@
+export function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/local.js
+++ b/src/local.js
@@ -142,6 +142,8 @@ export function createStylesRouteHandler({
 	transpilerUrl = process.env.SASS_TRANSPILER_URL?.trim() || DEFAULT_SASS_TRANSPILER_URL,
 }) {
 	let lastGoodCss = '';
+	let nextStylesRequestId = 0;
+	let lastAppliedStylesRequestId = 0;
 
 	const transpileEndpoint = `${transpilerUrl.replace(/\/$/, '')}/transpile`;
 
@@ -209,6 +211,7 @@ export function createStylesRouteHandler({
 
 	return async function stylesRouteHandler(req, res) {
 		res.set('Content-Type', 'text/css');
+		const stylesRequestId = ++nextStylesRequestId;
 
 		let styles;
 		try {
@@ -232,7 +235,10 @@ export function createStylesRouteHandler({
 		const { response, bodyText } = transpileResult;
 
 		if (response.ok) {
-			lastGoodCss = bodyText;
+			if (stylesRequestId >= lastAppliedStylesRequestId) {
+				lastGoodCss = bodyText;
+				lastAppliedStylesRequestId = stylesRequestId;
+			}
 			res.send(bodyText);
 			return;
 		}

--- a/src/local.js
+++ b/src/local.js
@@ -148,7 +148,7 @@ export function createStylesRouteHandler({
 
 	const transpileEndpoint = `${transpilerUrl.replace(/\/$/, '')}/transpile`;
 
-	async function sendFallback(res, errorText = '') {
+	function sendFallback(res, errorText = '') {
 		if (hasLastGoodCss(lastGoodCss)) {
 			res.send(lastGoodCss);
 			return;
@@ -175,6 +175,39 @@ export function createStylesRouteHandler({
 		return { response, bodyText };
 	}
 
+	async function transpileStylesWithSingleRetry(fullStyles) {
+		let firstError = null;
+		let firstResult = null;
+
+		try {
+			firstResult = await transpileStyles(fullStyles);
+		} catch (err) {
+			firstError = err;
+		}
+
+		const shouldRetry =
+			firstError !== null ||
+			(firstResult !== null && firstResult.response.status >= 500);
+
+		if (!shouldRetry) {
+			if (firstResult !== null) {
+				return firstResult;
+			}
+			throw firstError;
+		}
+
+		await waitFn(retryDelayMs);
+
+		try {
+			return await transpileStyles(fullStyles);
+		} catch (retryErr) {
+			if (firstError) {
+				logs.error(firstError);
+			}
+			throw retryErr;
+		}
+	}
+
 	return async function stylesRouteHandler(req, res) {
 		res.set('Content-Type', 'text/css');
 
@@ -183,23 +216,18 @@ export function createStylesRouteHandler({
 			styles = await processStylesFn({ campaign: campaignPath });
 		} catch (err) {
 			logs.error(err);
-			await sendFallback(res);
+			sendFallback(res);
 			return;
 		}
 
 		const fullStyles = baseStyles + styles;
 		let transpileResult;
 		try {
-			transpileResult = await transpileStyles(fullStyles);
+			transpileResult = await transpileStylesWithSingleRetry(fullStyles);
 		} catch (err) {
-			try {
-				await waitFn(retryDelayMs);
-				transpileResult = await transpileStyles(fullStyles);
-			} catch (retryErr) {
-				logs.error(retryErr);
-				await sendFallback(res);
-				return;
-			}
+			logs.error(err);
+			sendFallback(res);
+			return;
 		}
 
 		const { response, bodyText } = transpileResult;
@@ -208,41 +236,6 @@ export function createStylesRouteHandler({
 			lastGoodCss = bodyText;
 			res.send(bodyText);
 			return;
-		}
-
-		if (response.status >= 500) {
-			try {
-				await waitFn(retryDelayMs);
-				const retryResult = await transpileStyles(fullStyles);
-				if (retryResult.response.ok) {
-					lastGoodCss = retryResult.bodyText;
-					res.send(retryResult.bodyText);
-					return;
-				}
-
-				if (retryResult.response.status >= 400 && retryResult.response.status < 500) {
-					if (retryResult.response.status === 401) {
-						logs.warn(
-							'SASS transpiler returned 401; your token may be stale. Run `raisely login` if this keeps happening.'
-						);
-					}
-					if (retryResult.bodyText) {
-						logs.error(retryResult.bodyText);
-					}
-					await sendFallback(res, retryResult.bodyText);
-					return;
-				}
-
-				logs.error(
-					`SASS transpiler failed after retry: ${retryResult.response.status} ${retryResult.response.statusText}`
-				);
-				await sendFallback(res);
-				return;
-			} catch (retryErr) {
-				logs.error(retryErr);
-				await sendFallback(res);
-				return;
-			}
 		}
 
 		if (response.status >= 400 && response.status < 500) {
@@ -254,14 +247,17 @@ export function createStylesRouteHandler({
 			if (bodyText) {
 				logs.error(bodyText);
 			}
-			await sendFallback(res, bodyText);
+			sendFallback(res, bodyText);
 			return;
 		}
 
+		if (bodyText) {
+			logs.error(bodyText);
+		}
 		logs.error(
-			`SASS transpiler failed: ${response.status} ${response.statusText}`
+			`SASS transpiler failed after retry: ${response.status} ${response.statusText}`
 		);
-		await sendFallback(res);
+		sendFallback(res);
 	};
 }
 

--- a/src/local.js
+++ b/src/local.js
@@ -33,6 +33,8 @@ import { loadConfig } from './config.js';
 // local development config
 const PORT = 8015;
 const DEFAULT_API_URL = 'https://api.raisely.com';
+const DEFAULT_SASS_TRANSPILER_URL = 'https://sass-transpiler.raisely.com';
+const DEFAULT_TRANSPILE_RETRY_DELAY_MS = 500;
 
 /**
  * Build a small script that, only when the user has opted into a non-prod API,
@@ -119,6 +121,150 @@ async function decodeProxyResponseBuffer(responseBuffer, proxyRes) {
 	return responseBuffer.toString('utf8');
 }
 
+function buildCssErrorComment(errorMessage) {
+	return `/*\n${errorMessage}\n*/`;
+}
+
+function hasLastGoodCss(css) {
+	return typeof css === 'string' && css.length > 0;
+}
+
+function wait(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function createStylesRouteHandler({
+	campaignPath,
+	baseStyles,
+	token,
+	processStylesFn = processStyles,
+	fetchFn = fetch,
+	logs = console,
+	retryDelayMs = DEFAULT_TRANSPILE_RETRY_DELAY_MS,
+	waitFn = wait,
+	transpilerUrl = process.env.SASS_TRANSPILER_URL?.trim() || DEFAULT_SASS_TRANSPILER_URL,
+}) {
+	let lastGoodCss = '';
+
+	const transpileEndpoint = `${transpilerUrl.replace(/\/$/, '')}/transpile`;
+
+	async function sendFallback(res, errorText = '') {
+		if (hasLastGoodCss(lastGoodCss)) {
+			res.send(lastGoodCss);
+			return;
+		}
+
+		if (errorText) {
+			res.status(502).send(buildCssErrorComment(errorText));
+			return;
+		}
+
+		res.sendStatus(502);
+	}
+
+	async function transpileStyles(fullStyles) {
+		const response = await fetchFn(transpileEndpoint, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/scss',
+				Authorization: `Bearer ${token}`,
+			},
+			body: fullStyles,
+		});
+		const bodyText = await response.text();
+		return { response, bodyText };
+	}
+
+	return async function stylesRouteHandler(req, res) {
+		res.set('Content-Type', 'text/css');
+
+		let styles;
+		try {
+			styles = await processStylesFn({ campaign: campaignPath });
+		} catch (err) {
+			logs.error(err);
+			await sendFallback(res);
+			return;
+		}
+
+		const fullStyles = baseStyles + styles;
+		let transpileResult;
+		try {
+			transpileResult = await transpileStyles(fullStyles);
+		} catch (err) {
+			try {
+				await waitFn(retryDelayMs);
+				transpileResult = await transpileStyles(fullStyles);
+			} catch (retryErr) {
+				logs.error(retryErr);
+				await sendFallback(res);
+				return;
+			}
+		}
+
+		const { response, bodyText } = transpileResult;
+
+		if (response.ok) {
+			lastGoodCss = bodyText;
+			res.send(bodyText);
+			return;
+		}
+
+		if (response.status >= 500) {
+			try {
+				await waitFn(retryDelayMs);
+				const retryResult = await transpileStyles(fullStyles);
+				if (retryResult.response.ok) {
+					lastGoodCss = retryResult.bodyText;
+					res.send(retryResult.bodyText);
+					return;
+				}
+
+				if (retryResult.response.status >= 400 && retryResult.response.status < 500) {
+					if (retryResult.response.status === 401) {
+						logs.warn(
+							'SASS transpiler returned 401; your token may be stale. Run `raisely login` if this keeps happening.'
+						);
+					}
+					if (retryResult.bodyText) {
+						logs.error(retryResult.bodyText);
+					}
+					await sendFallback(res, retryResult.bodyText);
+					return;
+				}
+
+				logs.error(
+					`SASS transpiler failed after retry: ${retryResult.response.status} ${retryResult.response.statusText}`
+				);
+				await sendFallback(res);
+				return;
+			} catch (retryErr) {
+				logs.error(retryErr);
+				await sendFallback(res);
+				return;
+			}
+		}
+
+		if (response.status >= 400 && response.status < 500) {
+			if (response.status === 401) {
+				logs.warn(
+					'SASS transpiler returned 401; your token may be stale. Run `raisely login` if this keeps happening.'
+				);
+			}
+			if (bodyText) {
+				logs.error(bodyText);
+			}
+			await sendFallback(res, bodyText);
+			return;
+		}
+
+		logs.error(
+			`SASS transpiler failed: ${response.status} ${response.statusText}`
+		);
+		await sendFallback(res);
+	};
+}
+
 export default async function start(options = {}) {
 	welcome();
 
@@ -200,51 +346,14 @@ export default async function start(options = {}) {
 	});
 
 	// locally compile css files
-	app.use(`/v3/campaigns/${campaignUuid}/styles.css`, async (req, res) => {
-		res.set('Content-Type', 'text/css');
-
-		try {
-			const transpilerUrl =
-				process.env.SASS_TRANSPILER_URL?.trim() ||
-				'https://sass-transpiler.raisely.com';
-
-			const styles = await processStyles({
-				campaign: campaignPath,
-			});
-
-			const response = await fetch(
-				`${transpilerUrl.replace(/\/$/, '')}/transpile`,
-				{
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/scss',
-						Authorization: `Bearer ${config.token}`,
-					},
-					body: base + styles,
-				}
-			);
-
-			if (response.status === 401) {
-				console.error(
-					'SASS transpiler returned 401: token rejected when validating against the API.'
-				);
-				res.sendStatus(401);
-				process.exit(1);
-			}
-			if (!response.ok) {
-				console.error(
-					`SASS transpiler failed: ${response.status} ${response.statusText}`
-				);
-				return res.sendStatus(502);
-			}
-
-			const css = await response.text();
-			res.send(css);
-		} catch (e) {
-			console.error(e);
-			res.sendStatus(500);
-		}
-	});
+	app.use(
+		`/v3/campaigns/${campaignUuid}/styles.css`,
+		createStylesRouteHandler({
+			campaignPath,
+			baseStyles: base,
+			token: config.token,
+		})
+	);
 
 	// locally compile components
 	app.use(`/v3/campaigns/${campaignUuid}/components.js`, async (req, res) => {

--- a/src/local.js
+++ b/src/local.js
@@ -27,6 +27,7 @@ import {
 	compileAllLocalPages,
 	buildPageOverrideScript,
 } from './actions/pages.js';
+import { sleep } from './actions/sleep.js';
 import { getToken } from './actions/auth.js';
 import { loadConfig } from './config.js';
 
@@ -129,10 +130,6 @@ function hasLastGoodCss(css) {
 	return typeof css === 'string' && css.length > 0;
 }
 
-function wait(ms) {
-	return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 export function createStylesRouteHandler({
 	campaignPath,
 	baseStyles,
@@ -141,7 +138,7 @@ export function createStylesRouteHandler({
 	fetchFn = fetch,
 	logs = console,
 	retryDelayMs = DEFAULT_TRANSPILE_RETRY_DELAY_MS,
-	waitFn = wait,
+	waitFn = sleep,
 	transpilerUrl = process.env.SASS_TRANSPILER_URL?.trim() || DEFAULT_SASS_TRANSPILER_URL,
 }) {
 	let lastGoodCss = '';
@@ -193,7 +190,9 @@ export function createStylesRouteHandler({
 			if (firstResult !== null) {
 				return firstResult;
 			}
-			throw firstError;
+			throw new Error(
+				'Unexpected transpile state: missing result and error before retry'
+			);
 		}
 
 		await waitFn(retryDelayMs);

--- a/tests/local.test.js
+++ b/tests/local.test.js
@@ -58,6 +58,16 @@ function hasLogMessage(entries, expectedMessage) {
 	);
 }
 
+function createDeferred() {
+	let resolve;
+	let reject;
+	const promise = new Promise((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
 describe('local styles route', () => {
 	test('cold cache 4xx returns 502 with transpiler error as css comment', async () => {
 		const logs = createLogger();
@@ -273,5 +283,62 @@ describe('local styles route', () => {
 			),
 			true
 		);
+	});
+
+	test('older in-flight success does not overwrite newer cached css', async () => {
+		const logs = createLogger();
+		const firstFetch = createDeferred();
+		const secondFetch = createDeferred();
+		let fetchCalls = 0;
+
+		const handler = createStylesRouteHandler({
+			campaignPath: 'my-campaign',
+			baseStyles: '',
+			token: 'token-123',
+			processStylesFn: async () => '.hero { color: red; }',
+			fetchFn: async () => {
+				fetchCalls += 1;
+				if (fetchCalls === 1) return firstFetch.promise;
+				if (fetchCalls === 2) return secondFetch.promise;
+				return makeTranspilerResponse({
+					status: 400,
+					body: 'SassError: broken',
+					statusText: 'Bad Request',
+				});
+			},
+			logs,
+		});
+
+		const firstRes = makeResponseHarness();
+		const secondRes = makeResponseHarness();
+
+		const firstRequest = handler({}, firstRes);
+		const secondRequest = handler({}, secondRes);
+
+		secondFetch.resolve(
+			makeTranspilerResponse({
+				status: 200,
+				body: '.newest { color: green; }',
+				statusText: 'OK',
+			})
+		);
+		firstFetch.resolve(
+			makeTranspilerResponse({
+				status: 200,
+				body: '.stale { color: red; }',
+				statusText: 'OK',
+			})
+		);
+
+		await Promise.all([firstRequest, secondRequest]);
+
+		assert.equal(secondRes.body, '.newest { color: green; }');
+		assert.equal(firstRes.body, '.stale { color: red; }');
+
+		const fallbackRes = makeResponseHarness();
+		await handler({}, fallbackRes);
+
+		assert.equal(fallbackRes.statusCode, 200);
+		assert.equal(fallbackRes.body, '.newest { color: green; }');
 	});
 });

--- a/tests/local.test.js
+++ b/tests/local.test.js
@@ -1,0 +1,212 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createStylesRouteHandler } from '../src/local.js';
+
+function makeTranspilerResponse({ status, body = '', statusText = '' }) {
+	return {
+		status,
+		ok: status >= 200 && status < 300,
+		statusText,
+		text: async () => body,
+	};
+}
+
+function makeResponseHarness() {
+	return {
+		headers: {},
+		statusCode: 200,
+		body: undefined,
+		set(name, value) {
+			this.headers[name] = value;
+			return this;
+		},
+		status(code) {
+			this.statusCode = code;
+			return this;
+		},
+		send(payload) {
+			this.body = payload;
+			return this;
+		},
+		sendStatus(code) {
+			this.statusCode = code;
+			this.body = undefined;
+			return this;
+		},
+	};
+}
+
+function createLogger() {
+	return {
+		errors: [],
+		warns: [],
+		error(value) {
+			this.errors.push(value);
+		},
+		warn(value) {
+			this.warns.push(value);
+		},
+	};
+}
+
+describe('local styles route', () => {
+	test('cold cache 4xx returns 502 with transpiler error as css comment', async () => {
+		const logs = createLogger();
+		const handler = createStylesRouteHandler({
+			campaignPath: 'my-campaign',
+			baseStyles: '',
+			token: 'token-123',
+			processStylesFn: async () => '.hero { color: red; }',
+			fetchFn: async () =>
+				makeTranspilerResponse({
+					status: 422,
+					body: 'Error: expected "}" on line 2',
+					statusText: 'Unprocessable Entity',
+				}),
+			logs,
+		});
+
+		const res = makeResponseHarness();
+		await handler({}, res);
+
+		assert.equal(res.statusCode, 502);
+		assert.equal(
+			res.body,
+			'/*\nError: expected "}" on line 2\n*/'
+		);
+		assert.deepEqual(logs.errors, ['Error: expected "}" on line 2']);
+	});
+
+	test('warm cache 4xx serves last good css and logs transpiler error', async () => {
+		const logs = createLogger();
+		const queue = [
+			makeTranspilerResponse({
+				status: 200,
+				body: '.fresh { color: green; }',
+				statusText: 'OK',
+			}),
+			makeTranspilerResponse({
+				status: 400,
+				body: 'SassError: invalid selector',
+				statusText: 'Bad Request',
+			}),
+		];
+
+		const handler = createStylesRouteHandler({
+			campaignPath: 'my-campaign',
+			baseStyles: '',
+			token: 'token-123',
+			processStylesFn: async () => '.hero { color: red; }',
+			fetchFn: async () => queue.shift(),
+			logs,
+		});
+
+		const firstRes = makeResponseHarness();
+		await handler({}, firstRes);
+		assert.equal(firstRes.statusCode, 200);
+		assert.equal(firstRes.body, '.fresh { color: green; }');
+
+		const secondRes = makeResponseHarness();
+		await handler({}, secondRes);
+		assert.equal(secondRes.statusCode, 200);
+		assert.equal(secondRes.body, '.fresh { color: green; }');
+		assert.deepEqual(logs.errors, ['SassError: invalid selector']);
+	});
+
+	test('401 warns and keeps serving from cache on later requests', async () => {
+		const logs = createLogger();
+		const queue = [
+			makeTranspilerResponse({
+				status: 200,
+				body: '.cached { color: blue; }',
+				statusText: 'OK',
+			}),
+			makeTranspilerResponse({
+				status: 401,
+				body: 'Unauthorized',
+				statusText: 'Unauthorized',
+			}),
+			makeTranspilerResponse({
+				status: 200,
+				body: '.new { color: purple; }',
+				statusText: 'OK',
+			}),
+		];
+
+		const handler = createStylesRouteHandler({
+			campaignPath: 'my-campaign',
+			baseStyles: '',
+			token: 'token-123',
+			processStylesFn: async () => '.hero { color: red; }',
+			fetchFn: async () => queue.shift(),
+			logs,
+		});
+
+		const firstRes = makeResponseHarness();
+		await handler({}, firstRes);
+		assert.equal(firstRes.body, '.cached { color: blue; }');
+
+		const secondRes = makeResponseHarness();
+		await handler({}, secondRes);
+		assert.equal(secondRes.statusCode, 200);
+		assert.equal(secondRes.body, '.cached { color: blue; }');
+
+		const thirdRes = makeResponseHarness();
+		await handler({}, thirdRes);
+		assert.equal(thirdRes.statusCode, 200);
+		assert.equal(thirdRes.body, '.new { color: purple; }');
+		assert.equal(logs.warns.length, 1);
+		assert.equal(logs.errors.includes('Unauthorized'), true);
+	});
+
+	test('5xx retries once after 500ms before falling back', async () => {
+		const logs = createLogger();
+		let fetchCalls = 0;
+		let waitCalls = 0;
+		const queue = [
+			makeTranspilerResponse({
+				status: 200,
+				body: '.baseline { color: black; }',
+				statusText: 'OK',
+			}),
+			makeTranspilerResponse({
+				status: 503,
+				body: 'Service unavailable',
+				statusText: 'Service Unavailable',
+			}),
+			makeTranspilerResponse({
+				status: 503,
+				body: 'Still unavailable',
+				statusText: 'Service Unavailable',
+			}),
+		];
+
+		const handler = createStylesRouteHandler({
+			campaignPath: 'my-campaign',
+			baseStyles: '',
+			token: 'token-123',
+			processStylesFn: async () => '.hero { color: red; }',
+			fetchFn: async () => {
+				fetchCalls += 1;
+				return queue.shift();
+			},
+			waitFn: async () => {
+				waitCalls += 1;
+			},
+			logs,
+		});
+
+		const firstRes = makeResponseHarness();
+		await handler({}, firstRes);
+		assert.equal(firstRes.body, '.baseline { color: black; }');
+
+		const secondRes = makeResponseHarness();
+		await handler({}, secondRes);
+		assert.equal(secondRes.statusCode, 200);
+		assert.equal(secondRes.body, '.baseline { color: black; }');
+		assert.equal(waitCalls, 1);
+		assert.equal(fetchCalls, 3);
+		assert.equal(logs.errors.length > 0, true);
+	});
+});

--- a/tests/local.test.js
+++ b/tests/local.test.js
@@ -207,6 +207,63 @@ describe('local styles route', () => {
 		assert.equal(secondRes.body, '.baseline { color: black; }');
 		assert.equal(waitCalls, 1);
 		assert.equal(fetchCalls, 3);
-		assert.equal(logs.errors.length > 0, true);
+		assert.equal(logs.errors.includes('Still unavailable'), true);
+		assert.equal(
+			logs.errors.some(
+				(entry) =>
+					typeof entry === 'string' &&
+					entry.includes('SASS transpiler failed after retry: 503')
+			),
+			true
+		);
+	});
+
+	test('network error then 5xx only retries once total', async () => {
+		const logs = createLogger();
+		let fetchCalls = 0;
+		let waitCalls = 0;
+		const firstError = new Error('socket hang up');
+		const queue = [
+			'throw',
+			makeTranspilerResponse({
+				status: 503,
+				body: 'Service unavailable',
+				statusText: 'Service Unavailable',
+			}),
+		];
+
+		const handler = createStylesRouteHandler({
+			campaignPath: 'my-campaign',
+			baseStyles: '',
+			token: 'token-123',
+			processStylesFn: async () => '.hero { color: red; }',
+			fetchFn: async () => {
+				fetchCalls += 1;
+				const next = queue.shift();
+				if (next === 'throw') {
+					throw firstError;
+				}
+				return next;
+			},
+			waitFn: async () => {
+				waitCalls += 1;
+			},
+			logs,
+		});
+
+		const res = makeResponseHarness();
+		await handler({}, res);
+
+		assert.equal(waitCalls, 1);
+		assert.equal(fetchCalls, 2);
+		assert.equal(res.statusCode, 502);
+		assert.equal(
+			logs.errors.some(
+				(entry) =>
+					typeof entry === 'string' &&
+					entry.includes('SASS transpiler failed after retry: 503')
+			),
+			true
+		);
 	});
 });

--- a/tests/local.test.js
+++ b/tests/local.test.js
@@ -50,6 +50,14 @@ function createLogger() {
 	};
 }
 
+function hasLogMessage(entries, expectedMessage) {
+	return entries.some(
+		(entry) =>
+			typeof entry === 'string' &&
+			entry.includes(expectedMessage)
+	);
+}
+
 describe('local styles route', () => {
 	test('cold cache 4xx returns 502 with transpiler error as css comment', async () => {
 		const logs = createLogger();
@@ -157,7 +165,7 @@ describe('local styles route', () => {
 		assert.equal(thirdRes.statusCode, 200);
 		assert.equal(thirdRes.body, '.new { color: purple; }');
 		assert.equal(logs.warns.length, 1);
-		assert.equal(logs.errors.includes('Unauthorized'), true);
+		assert.equal(hasLogMessage(logs.errors, 'Unauthorized'), true);
 	});
 
 	test('5xx retries once after 500ms before falling back', async () => {
@@ -207,7 +215,7 @@ describe('local styles route', () => {
 		assert.equal(secondRes.body, '.baseline { color: black; }');
 		assert.equal(waitCalls, 1);
 		assert.equal(fetchCalls, 3);
-		assert.equal(logs.errors.includes('Still unavailable'), true);
+		assert.equal(hasLogMessage(logs.errors, 'Still unavailable'), true);
 		assert.equal(
 			logs.errors.some(
 				(entry) =>


### PR DESCRIPTION
## What changed

- Added resilient CSS handling in `raisely local` using an in-memory `lastGoodCss` cache.
- Updated transpiler failure handling so 4xx errors log clearly and fall back to cached CSS, with CSS-comment errors when cache is empty.
- Changed 401 behavior to warn and keep serving, instead of exiting the process.
- Added single retry after 500ms for 5xx and network failures, then fallback.

## Why

- Keeps local pages styled while SCSS is being fixed.
- Surfaces transpiler errors in both terminal output and browser tooling.
- Prevents local dev sessions from crashing on stale auth tokens.

## validation

- `npm test` passes with all tests green.
- Added route tests covering cold cache, warm cache, 401, and 5xx paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes local development server behavior for CSS transpilation with new retry and caching logic. Well-covered by comprehensive tests, but modifies critical path for local development styling.
> 
> **Overview**
> Adds resilient CSS handling to `raisely local` with an in-memory `lastGoodCss` cache that keeps pages styled when SCSS transpilation fails. The new `createStylesRouteHandler` function implements:
> 
> - **Caching**: Stores successful transpilation results and serves them on subsequent failures.
> - **Retry logic**: Single retry after 500ms for 5xx errors and network failures.
> - **Graceful degradation**: 4xx errors return cached CSS if available, or a 502 with the error wrapped in a CSS comment when cache is empty.
> - **Improved 401 handling**: Warns about stale tokens instead of crashing the process.
> - **Race condition protection**: Request ID tracking prevents older in-flight responses from overwriting newer cached CSS.
> 
> Also extracts the `sleep` utility into a shared module for reuse across the codebase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9cd0e694e842fdb41b388ba9fd1433253283eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->