### PR TITLE
raisely local: configurable port + agent docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ For other issues, [submit a support ticket](mailto:support@raisely.com).
 -   `raisely deploy` - deploy your local code to Raisely (styles, components, and pages)
 -   `raisely local` - work locally on a Raisely campaign without syncing changes up (includes local page JSON overrides when `pages/` is present)
 -   `raisely local --uuid <uuid>` - open a specific campaign by UUID, skipping the picker
+-   `raisely local --port <port>` - run the local development server on a custom port instead of `8015`
 
 ### Custom public host (`raisely local`)
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,4 @@
-import { program } from 'commander';
+import { InvalidArgumentError, program } from 'commander';
 import { getPackageInfo } from './helpers.js';
 
 /**
@@ -12,6 +12,14 @@ function actionBuilder(moduleLoader) {
 		const { default: commandContext } = await moduleLoader();
 		await commandContext(...args);
 	};
+}
+
+function parsePort(value) {
+	const port = Number(value);
+	if (!Number.isInteger(port) || port < 1 || port > 65535) {
+		throw new InvalidArgumentError('Port must be an integer between 1 and 65535');
+	}
+	return port;
 }
 
 // define actions
@@ -91,6 +99,7 @@ export async function cli() {
 			'--uuid <uuid>',
 			'Open a specific campaign by UUID (skips the campaign picker)'
 		)
+		.option('--port <port>', 'Override the local server port', parsePort, 8015)
 		.option('--no-open', 'Do not open a browser window')
 		.action(local);
 

--- a/src/local.js
+++ b/src/local.js
@@ -31,7 +31,7 @@ import { getToken } from './actions/auth.js';
 import { loadConfig } from './config.js';
 
 // local development config
-const PORT = 8015;
+const DEFAULT_PORT = 8015;
 const DEFAULT_API_URL = 'https://api.raisely.com';
 
 /**
@@ -39,7 +39,7 @@ const DEFAULT_API_URL = 'https://api.raisely.com';
  * rewrites browser API calls from https://api.raisely.com to config.apiUrl.
  *
  * The campaign's frontend bundle picks its API host from window.location.hostname,
- * so when it's loaded over http://localhost:8015 it falls through to api.raisely.com.
+ * so when it's loaded over localhost it falls through to api.raisely.com.
  * Patching fetch/XHR sidesteps that resolver without changing the bundle.
  *
  * Returns an empty string when apiUrl is the production default, so prod/staging
@@ -121,6 +121,7 @@ async function decodeProxyResponseBuffer(responseBuffer, proxyRes) {
 
 export default async function start(options = {}) {
 	welcome();
+	const port = options.port || DEFAULT_PORT;
 
 	// load config
 	const config = await loadConfig();
@@ -292,7 +293,7 @@ export default async function start(options = {}) {
 					// embeds api.raisely.com, api.raisely.test:2999, or any other host.
 					const stylesPath = `/v3/campaigns/${campaignUuid}/styles.css`;
 					const componentsPath = `/v3/campaigns/${campaignUuid}/components.js`;
-					const localBase = `http://localhost:${PORT}`;
+					const localBase = `http://localhost:${port}`;
 					const upstreamUrlRe = (path) =>
 						new RegExp(
 							`https?://[^"'\\s)]+${path.replace(/[/.]/g, '\\$&')}`,
@@ -367,7 +368,7 @@ export default async function start(options = {}) {
 		})
 	);
 
-	app.listen(PORT);
+	app.listen(port);
 
 	log(`Local development for ${target} has been set up in:`, 'white');
 	br();
@@ -383,12 +384,12 @@ export default async function start(options = {}) {
 	} else {
 		log(`Your development site:`, 'white');
 	}
-	log(`http://localhost:${PORT}`, 'white');
+	log(`http://localhost:${port}`, 'white');
 	br();
 	log(`Use CTRL + C to stop`, 'white');
 
 	if (options.open) {
-		open(`http://localhost:${PORT}`, {
+		open(`http://localhost:${port}`, {
 			background: true,
 		});
 	}


### PR DESCRIPTION
## Summary
Adds a --port option to raisely local so the dev server can bind to a port other than 8015, with CLI validation. Also introduces README documents raisely local --port <port>.

## Changes
- `src/cli.js`: `--port <port>` on `local`; parses via Commander using integer validation (`InvalidArgumentError` if outside 1–65535); default remains `8015`.
- `src/local.js`: Replaces fixed PORT with runtime port from options (`DEFAULT_PORT` fallback); listen URL, logged URL, proxy rewrite base (`localhost:${port})`, and `--open` target all follow the chosen port. Comment updated so it doesn’t hard-code `:8015`.
- `README.md`: Bullet for `raisely local --port <port>`.

### How to verify
`raisely local --port 9000`
Confirm the printed URL and opened browser use `9000`, and that invalid values error cleanly.

If this branch should stay narrowly scoped to the port feature, you might split out `AGENTS.md` and `docs/agents/*` into a follow-up PR; they landed in the same commit here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to local-development CLI behavior and documentation, with simple input validation and no production data-path, auth, or payment logic changes.
> 
> **Overview**
> `raisely local` now accepts `--port <port>` (default `8015`) with Commander validation, and the local dev server in `src/local.js` uses the selected port consistently for `app.listen`, proxy URL rewrites, logging, and the browser auto-open URL.
> 
> Updates `README.md` to document the new `--port` option.
> 
> ## Risk Assessment (Framework v2.0)
> - **Security/Privacy/PII**: Low
> - **Data integrity**: Low
> - **Critical paths (auth/payments/production runtime)**: Low
> - **Scope/complexity**: Low
> - **Observability/operability**: Low
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e690baac7a40a857d54bfa6f93d60d44ac8a37d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->