### PR TITLE
SIR-1521 - cli v2 shared scss and component validators

### DIFF
--- a/src/actions/babel.js
+++ b/src/actions/babel.js
@@ -1,0 +1,24 @@
+let BabelAlreadyLoaded = false;
+
+export async function loadBabelCore() {
+	const [
+		{ default: Babel },
+		{ default: presetEnv },
+		{ default: presetReact },
+		{ default: classProps },
+	] = await Promise.all([
+		import('@babel/core'),
+		import('@babel/preset-env'),
+		import('@babel/preset-react'),
+		import('@babel/plugin-proposal-class-properties'),
+	]);
+
+	if (!BabelAlreadyLoaded) {
+		Babel.createConfigItem(presetEnv);
+		Babel.createConfigItem(presetReact);
+		Babel.createConfigItem(classProps);
+		BabelAlreadyLoaded = true;
+	}
+
+	return { Babel, presetEnv, presetReact, classProps };
+}

--- a/src/actions/components.js
+++ b/src/actions/components.js
@@ -1,34 +1,8 @@
 import api from './api.js';
+import { loadBabelCore } from './babel.js';
 
 import path from 'path';
 import fs from 'fs';
-
-let BabelAlreadyLoaded = false;
-
-// Only load the Babel compiling core when needed
-async function loadBabelCore() {
-	const [
-		{ default: Babel },
-		{ default: presetEnv },
-		{ default: presetReact },
-		{ default: classProps },
-	] = await Promise.all([
-		import('@babel/core'),
-		import('@babel/preset-env'),
-		import('@babel/preset-react'),
-		import('@babel/plugin-proposal-class-properties'),
-	]);
-
-	if (!BabelAlreadyLoaded) {
-		Babel.createConfigItem(presetEnv);
-		Babel.createConfigItem(presetReact);
-		Babel.createConfigItem(classProps);
-		// flag as initialized
-		BabelAlreadyLoaded = true;
-	}
-
-	return { Babel, presetEnv, presetReact, classProps };
-}
 
 async function getComponent(uuid, opts = {}) {
 	return await api({

--- a/src/actions/validate.js
+++ b/src/actions/validate.js
@@ -15,8 +15,28 @@ const AUTH_FAILURE_ERROR = 'Authentication failed; run `raisely login`.';
 function resolveTranspilerUrl(raw) {
 	const fromEnv = raw?.trim();
 	if (!fromEnv) return DEFAULT_TRANSPILER_URL;
-	if (fromEnv.endsWith('/transpile')) return fromEnv;
-	return `${fromEnv.replace(/\/$/, '')}/transpile`;
+
+	try {
+		const parsed = new URL(fromEnv);
+		const normalizedPath = parsed.pathname
+			.replace(/\/{2,}/g, '/')
+			.replace(/\/+$/, '');
+
+		if (normalizedPath.endsWith('/transpile')) {
+			parsed.pathname = normalizedPath;
+			return parsed.toString();
+		}
+
+		parsed.pathname =
+			normalizedPath === '' || normalizedPath === '/'
+				? '/transpile'
+				: `${normalizedPath}/transpile`;
+		return parsed.toString();
+	} catch {
+		const normalized = fromEnv.replace(/\/+$/, '');
+		if (normalized.endsWith('/transpile')) return normalized;
+		return `${normalized}/transpile`;
+	}
 }
 
 function toErrorMessage(error, fallback) {
@@ -32,6 +52,10 @@ function readResponseError(response, body) {
 	const text = typeof body === 'string' ? body.trim() : '';
 	if (text) return text;
 	return `${response.status} ${response.statusText}`.trim();
+}
+
+function hasUsableToken(token) {
+	return typeof token === 'string' && token.trim().length > 0;
 }
 
 async function resolveCampaignContext(campaign, deps) {
@@ -122,9 +146,12 @@ export async function validateCampaignSass(
 		const payload = `${baseStyles}${styles}`;
 
 		let activeToken = token;
-		if (!activeToken) {
+		if (!hasUsableToken(activeToken)) {
 			const creds = await deps.getCredentialsFn({ allowPrompt: false });
 			activeToken = creds.token;
+		}
+		if (!hasUsableToken(activeToken)) {
+			return { ok: false, error: AUTH_FAILURE_ERROR };
 		}
 
 		try {
@@ -156,6 +183,9 @@ export async function validateCampaignSass(
 			const refreshed = await deps.getCredentialsFn({ allowPrompt: false });
 			activeToken = refreshed.token;
 		} catch {
+			return { ok: false, error: AUTH_FAILURE_ERROR };
+		}
+		if (!hasUsableToken(activeToken)) {
 			return { ok: false, error: AUTH_FAILURE_ERROR };
 		}
 

--- a/src/actions/validate.js
+++ b/src/actions/validate.js
@@ -1,0 +1,235 @@
+import path from 'path';
+import fs from 'fs';
+
+import api from './api.js';
+import { getBaseStyles, processStyles } from './campaigns.js';
+import {
+	getCredentials,
+	refreshCredentialsForCurrentContext,
+} from '../credentials.js';
+
+const DEFAULT_TRANSPILER_URL = 'https://sass-transpiler.raisely.com/transpile';
+const AUTH_FAILURE_ERROR = 'Authentication failed; run `raisely login`.';
+
+let BabelAlreadyLoaded = false;
+
+async function loadBabelCore() {
+	const [
+		{ default: Babel },
+		{ default: presetEnv },
+		{ default: presetReact },
+		{ default: classProps },
+	] = await Promise.all([
+		import('@babel/core'),
+		import('@babel/preset-env'),
+		import('@babel/preset-react'),
+		import('@babel/plugin-proposal-class-properties'),
+	]);
+
+	if (!BabelAlreadyLoaded) {
+		Babel.createConfigItem(presetEnv);
+		Babel.createConfigItem(presetReact);
+		Babel.createConfigItem(classProps);
+		BabelAlreadyLoaded = true;
+	}
+
+	return { Babel, presetEnv, presetReact, classProps };
+}
+
+function resolveTranspilerUrl(raw) {
+	const fromEnv = raw?.trim();
+	if (!fromEnv) return DEFAULT_TRANSPILER_URL;
+	if (fromEnv.endsWith('/transpile')) return fromEnv;
+	return `${fromEnv.replace(/\/$/, '')}/transpile`;
+}
+
+function toErrorMessage(error, fallback) {
+	if (typeof error === 'string' && error.trim()) return error.trim();
+	if (error instanceof Error && error.message.trim()) return error.message.trim();
+	if (error && typeof error.message === 'string' && error.message.trim()) {
+		return error.message.trim();
+	}
+	return fallback;
+}
+
+function readResponseError(response, body) {
+	const text = typeof body === 'string' ? body.trim() : '';
+	if (text) return text;
+	return `${response.status} ${response.statusText}`.trim();
+}
+
+async function resolveCampaignContext(campaign, deps) {
+	if (!campaign) {
+		throw new Error('A campaign path or campaign object is required');
+	}
+
+	if (typeof campaign === 'object' && campaign.uuid && campaign.path) {
+		return { uuid: campaign.uuid, path: campaign.path };
+	}
+
+	if (typeof campaign === 'string') {
+		const fetched = await deps.apiFn({
+			path: `/campaigns/${campaign}?private=1`,
+			method: 'GET',
+		});
+		return { uuid: fetched.data.uuid, path: fetched.data.path };
+	}
+
+	if (typeof campaign === 'object' && campaign.uuid) {
+		const fetched = await deps.apiFn({
+			path: `/campaigns/${campaign.uuid}?private=1`,
+			method: 'GET',
+		});
+		return { uuid: fetched.data.uuid, path: fetched.data.path };
+	}
+
+	if (typeof campaign === 'object' && campaign.path) {
+		const fetched = await deps.apiFn({
+			path: `/campaigns/${campaign.path}?private=1`,
+			method: 'GET',
+		});
+		return { uuid: fetched.data.uuid, path: fetched.data.path };
+	}
+
+	throw new Error('A campaign path or campaign object is required');
+}
+
+async function sendSassToTranspiler({ body, token, deps }) {
+	const response = await deps.fetchImpl(deps.transpilerUrl, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/scss',
+			Authorization: `Bearer ${token}`,
+		},
+		body,
+	});
+	const responseText = await response.text();
+	return { response, responseText };
+}
+
+function buildDeps(overrides = {}) {
+	return {
+		fetchImpl: overrides.fetchImpl || globalThis.fetch,
+		apiFn: overrides.apiFn || api,
+		getBaseStylesFn: overrides.getBaseStylesFn || getBaseStyles,
+		processStylesFn: overrides.processStylesFn || processStyles,
+		getCredentialsFn: overrides.getCredentialsFn || getCredentials,
+		refreshCredentialsFn:
+			overrides.refreshCredentialsFn || refreshCredentialsForCurrentContext,
+		loadBabelCoreFn: overrides.loadBabelCoreFn || loadBabelCore,
+		fsModule: overrides.fsModule || fs,
+		cwd: overrides.cwd || process.cwd,
+		transpilerUrl: resolveTranspilerUrl(
+			overrides.transpilerUrl || process.env.SASS_TRANSPILER_URL
+		),
+	};
+}
+
+export async function validateCampaignSass(
+	{ campaign, token } = {},
+	dependencies = {}
+) {
+	const deps = buildDeps(dependencies);
+	if (typeof deps.fetchImpl !== 'function') {
+		return { ok: false, error: 'SASS validator fetch transport is not available.' };
+	}
+
+	try {
+		const { uuid, path: campaignPath } = await resolveCampaignContext(
+			campaign,
+			deps
+		);
+		const [baseStyles, styles] = await Promise.all([
+			deps.getBaseStylesFn({ uuid }),
+			deps.processStylesFn({ campaign: campaignPath }),
+		]);
+		const payload = `${baseStyles}${styles}`;
+
+		let activeToken = token;
+		if (!activeToken) {
+			const creds = await deps.getCredentialsFn({ allowPrompt: false });
+			activeToken = creds.token;
+		}
+
+		try {
+			const { response, responseText } = await sendSassToTranspiler({
+				body: payload,
+				token: activeToken,
+				deps,
+			});
+
+			if (response.ok) {
+				return { ok: true };
+			}
+
+			if (response.status !== 401) {
+				return { ok: false, error: readResponseError(response, responseText) };
+			}
+		} catch (error) {
+			return {
+				ok: false,
+				error: toErrorMessage(
+					error,
+					'Could not reach the SASS transpiler service.'
+				),
+			};
+		}
+
+		try {
+			await deps.refreshCredentialsFn();
+			const refreshed = await deps.getCredentialsFn({ allowPrompt: false });
+			activeToken = refreshed.token;
+		} catch {
+			return { ok: false, error: AUTH_FAILURE_ERROR };
+		}
+
+		try {
+			const { response, responseText } = await sendSassToTranspiler({
+				body: payload,
+				token: activeToken,
+				deps,
+			});
+
+			if (response.ok) {
+				return { ok: true };
+			}
+
+			if (response.status === 401) {
+				return { ok: false, error: AUTH_FAILURE_ERROR };
+			}
+
+			return { ok: false, error: readResponseError(response, responseText) };
+		} catch (error) {
+			return {
+				ok: false,
+				error: toErrorMessage(error, 'Could not reach the SASS transpiler service.'),
+			};
+		}
+	} catch (error) {
+		return { ok: false, error: toErrorMessage(error, 'SASS validation failed.') };
+	}
+}
+
+export async function validateComponent({ name } = {}, dependencies = {}) {
+	const deps = buildDeps(dependencies);
+
+	if (!name) {
+		return { ok: false, error: 'Component name is required.' };
+	}
+
+	try {
+		const sourcePath = path.join(deps.cwd(), 'components', name, `${name}.js`);
+		const source = deps.fsModule.readFileSync(sourcePath, 'utf8');
+		const { Babel, presetEnv, presetReact, classProps } =
+			await deps.loadBabelCoreFn();
+
+		await Babel.transformAsync(source, {
+			presets: [presetEnv, presetReact],
+			plugins: [classProps],
+		});
+
+		return { ok: true };
+	} catch (error) {
+		return { ok: false, error: toErrorMessage(error, 'Component validation failed.') };
+	}
+}

--- a/src/actions/validate.js
+++ b/src/actions/validate.js
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs';
 
 import api from './api.js';
+import { loadBabelCore } from './babel.js';
 import { getBaseStyles, processStyles } from './campaigns.js';
 import {
 	getCredentials,
@@ -10,31 +11,6 @@ import {
 
 const DEFAULT_TRANSPILER_URL = 'https://sass-transpiler.raisely.com/transpile';
 const AUTH_FAILURE_ERROR = 'Authentication failed; run `raisely login`.';
-
-let BabelAlreadyLoaded = false;
-
-async function loadBabelCore() {
-	const [
-		{ default: Babel },
-		{ default: presetEnv },
-		{ default: presetReact },
-		{ default: classProps },
-	] = await Promise.all([
-		import('@babel/core'),
-		import('@babel/preset-env'),
-		import('@babel/preset-react'),
-		import('@babel/plugin-proposal-class-properties'),
-	]);
-
-	if (!BabelAlreadyLoaded) {
-		Babel.createConfigItem(presetEnv);
-		Babel.createConfigItem(presetReact);
-		Babel.createConfigItem(classProps);
-		BabelAlreadyLoaded = true;
-	}
-
-	return { Babel, presetEnv, presetReact, classProps };
-}
 
 function resolveTranspilerUrl(raw) {
 	const fromEnv = raw?.trim();

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -137,6 +137,74 @@ describe('validateCampaignSass', () => {
 			error: 'socket hang up',
 		});
 	});
+
+	test('returns auth-failure when credentials have no token', async () => {
+		let called = false;
+		const result = await validateCampaignSass(
+			{
+				campaign: { uuid: 'campaign-uuid', path: 'my-campaign' },
+			},
+			{
+				getBaseStylesFn: async () => '.base{}',
+				processStylesFn: async () => '.local{}',
+				getCredentialsFn: async () => ({}),
+				fetchImpl: async () => {
+					called = true;
+					return response(200, '.compiled{}');
+				},
+			}
+		);
+
+		assert.deepEqual(result, {
+			ok: false,
+			error: 'Authentication failed; run `raisely login`.',
+		});
+		assert.equal(called, false);
+	});
+
+	test('normalizes transpiler URL with trailing slash after transpile', async () => {
+		let calledUrl = null;
+		const result = await validateCampaignSass(
+			{
+				campaign: { uuid: 'campaign-uuid', path: 'my-campaign' },
+				token: 'token-1',
+			},
+			{
+				transpilerUrl: 'https://sass.example.com/transpile/',
+				getBaseStylesFn: async () => '.base{}',
+				processStylesFn: async () => '.local{}',
+				fetchImpl: async (url) => {
+					calledUrl = url;
+					return response(200, '.compiled{}');
+				},
+			}
+		);
+
+		assert.deepEqual(result, { ok: true });
+		assert.equal(calledUrl, 'https://sass.example.com/transpile');
+	});
+
+	test('normalizes duplicate slashes before transpile path', async () => {
+		let calledUrl = null;
+		const result = await validateCampaignSass(
+			{
+				campaign: { uuid: 'campaign-uuid', path: 'my-campaign' },
+				token: 'token-1',
+			},
+			{
+				transpilerUrl: 'https://sass.example.com//transpile',
+				getBaseStylesFn: async () => '.base{}',
+				processStylesFn: async () => '.local{}',
+				fetchImpl: async (url) => {
+					calledUrl = url;
+					return response(200, '.compiled{}');
+				},
+			}
+		);
+
+		assert.deepEqual(result, { ok: true });
+		assert.equal(calledUrl, 'https://sass.example.com/transpile');
+	});
 });
 
 describe('validateComponent', () => {

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -1,0 +1,235 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+	validateCampaignSass,
+	validateComponent,
+} from '../src/actions/validate.js';
+
+function response(status, body = '', statusText = '') {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		statusText,
+		async text() {
+			return body;
+		},
+	};
+}
+
+describe('validateCampaignSass', () => {
+	test('returns ok=true when transpiler accepts styles', async () => {
+		const calls = [];
+		const result = await validateCampaignSass(
+			{
+				campaign: { uuid: 'campaign-uuid', path: 'my-campaign' },
+				token: 'token-1',
+			},
+			{
+				getBaseStylesFn: async () => '.base{}',
+				processStylesFn: async () => '.local{}',
+				fetchImpl: async (url, options) => {
+					calls.push({ url, options });
+					return response(200, '.compiled{}');
+				},
+			}
+		);
+
+		assert.deepEqual(result, { ok: true });
+		assert.equal(calls.length, 1);
+		assert.equal(calls[0].options.body, '.base{}.local{}');
+	});
+
+	test('returns transpiler error body for invalid scss', async () => {
+		const result = await validateCampaignSass(
+			{
+				campaign: { uuid: 'campaign-uuid', path: 'my-campaign' },
+				token: 'token-1',
+			},
+			{
+				getBaseStylesFn: async () => '.base{}',
+				processStylesFn: async () => '.local{}',
+				fetchImpl: async () =>
+					response(422, 'Expected ";" after property value'),
+			}
+		);
+
+		assert.deepEqual(result, {
+			ok: false,
+			error: 'Expected ";" after property value',
+		});
+	});
+
+	test('refreshes once on first 401 and retries successfully', async () => {
+		let attempts = 0;
+		let refreshCount = 0;
+		const result = await validateCampaignSass(
+			{
+				campaign: { uuid: 'campaign-uuid', path: 'my-campaign' },
+				token: 'expired-token',
+			},
+			{
+				getBaseStylesFn: async () => '.base{}',
+				processStylesFn: async () => '.local{}',
+				refreshCredentialsFn: async () => {
+					refreshCount += 1;
+				},
+				getCredentialsFn: async () => ({ token: 'fresh-token' }),
+				fetchImpl: async (_url, options) => {
+					attempts += 1;
+					if (attempts === 1) {
+						assert.equal(options.headers.Authorization, 'Bearer expired-token');
+						return response(401, 'Unauthorized');
+					}
+					assert.equal(options.headers.Authorization, 'Bearer fresh-token');
+					return response(200, '.compiled{}');
+				},
+			}
+		);
+
+		assert.deepEqual(result, { ok: true });
+		assert.equal(refreshCount, 1);
+		assert.equal(attempts, 2);
+	});
+
+	test('returns auth-failure shape after second 401', async () => {
+		let refreshCount = 0;
+		const result = await validateCampaignSass(
+			{
+				campaign: { uuid: 'campaign-uuid', path: 'my-campaign' },
+				token: 'expired-token',
+			},
+			{
+				getBaseStylesFn: async () => '.base{}',
+				processStylesFn: async () => '.local{}',
+				refreshCredentialsFn: async () => {
+					refreshCount += 1;
+				},
+				getCredentialsFn: async () => ({ token: 'still-expired-token' }),
+				fetchImpl: async () => response(401, 'Unauthorized'),
+			}
+		);
+
+		assert.deepEqual(result, {
+			ok: false,
+			error: 'Authentication failed; run `raisely login`.',
+		});
+		assert.equal(refreshCount, 1);
+	});
+
+	test('returns blocking error on network failures', async () => {
+		const result = await validateCampaignSass(
+			{
+				campaign: { uuid: 'campaign-uuid', path: 'my-campaign' },
+				token: 'token-1',
+			},
+			{
+				getBaseStylesFn: async () => '.base{}',
+				processStylesFn: async () => '.local{}',
+				fetchImpl: async () => {
+					throw new Error('socket hang up');
+				},
+			}
+		);
+
+		assert.deepEqual(result, {
+			ok: false,
+			error: 'socket hang up',
+		});
+	});
+});
+
+describe('validateComponent', () => {
+	test('returns ok=true for valid component source', async () => {
+		let transformed = 0;
+		const result = await validateComponent(
+			{ name: 'SignupForm' },
+			{
+				cwd: () => '/repo',
+				fsModule: {
+					readFileSync(filePath) {
+						assert.equal(
+							filePath,
+							'/repo/components/SignupForm/SignupForm.js'
+						);
+						return 'export default () => <div />;';
+					},
+				},
+				loadBabelCoreFn: async () => ({
+					Babel: {
+						async transformAsync() {
+							transformed += 1;
+							return { code: 'ok' };
+						},
+					},
+					presetEnv: Symbol('presetEnv'),
+					presetReact: Symbol('presetReact'),
+					classProps: Symbol('classProps'),
+				}),
+			}
+		);
+
+		assert.deepEqual(result, { ok: true });
+		assert.equal(transformed, 1);
+	});
+
+	test('returns babel error for invalid component syntax', async () => {
+		const result = await validateComponent(
+			{ name: 'BrokenComponent' },
+			{
+				cwd: () => '/repo',
+				fsModule: {
+					readFileSync() {
+						return 'export default () => <div>';
+					},
+				},
+				loadBabelCoreFn: async () => ({
+					Babel: {
+						async transformAsync() {
+							throw new Error('Unexpected token (1:25)');
+						},
+					},
+					presetEnv: Symbol('presetEnv'),
+					presetReact: Symbol('presetReact'),
+					classProps: Symbol('classProps'),
+				}),
+			}
+		);
+
+		assert.deepEqual(result, {
+			ok: false,
+			error: 'Unexpected token (1:25)',
+		});
+	});
+
+	test('returns babel error for unsupported language feature', async () => {
+		const result = await validateComponent(
+			{ name: 'UnsupportedSyntax' },
+			{
+				cwd: () => '/repo',
+				fsModule: {
+					readFileSync() {
+						return 'export default () => null;';
+					},
+				},
+				loadBabelCoreFn: async () => ({
+					Babel: {
+						async transformAsync() {
+							throw new Error(
+								'Support for the experimental syntax is not currently enabled'
+							);
+						},
+					},
+					presetEnv: Symbol('presetEnv'),
+					presetReact: Symbol('presetReact'),
+					classProps: Symbol('classProps'),
+				}),
+			}
+		);
+
+		assert.deepEqual(result, {
+			ok: false,
+			error: 'Support for the experimental syntax is not currently enabled',
+		});
+	});
+});


### PR DESCRIPTION
## What changed

- Added shared validators for campaign SCSS and component source code.
- SCSS validation now uses the same transpiler payload shape as runtime, including base styles plus local styles.
- Added one silent token refresh on the first transpiler `401`; a second `401` returns a clear `raisely login`-style auth failure.
- Validators now return structured `{ ok, error }` results for all failure paths instead of throwing or exiting.
- Added coverage for success and failure cases, including transpiler network errors and Babel compile errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new validation flows that call an external SASS transpiler and include token refresh/retry logic on `401`, so auth and network error handling could affect CLI behavior. Changes are localized and well-tested but touch credential usage paths.
> 
> **Overview**
> Adds shared validation utilities for the CLI: `validateCampaignSass` posts the runtime-equivalent SCSS payload (*base styles + local styles*) to a configurable transpiler endpoint and returns structured `{ ok, error }`, including a single token refresh + retry on initial `401`.
> 
> Adds `validateComponent` to compile a local component source file with Babel and return `{ ok, error }` instead of throwing. Refactors Babel lazy-loading into a new shared `loadBabelCore` helper and adds unit coverage for success/failure, network errors, auth retry behavior, and transpiler URL normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67c1682eb7cb4d51c2602f9b9db9970df2d18b8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->