### PR TITLE
SIR-1524 - Update v2 release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+# 2.0.0
+- Breaking layout change: per-campaign content now lives in `campaigns/<campaign-path>/`, the entry SCSS file is now `main.scss`, and shared components remain at the repo root.
+- Added `raisely migrate` to upgrade existing repositories from the v1 layout to the v2 layout.
+- Added SCSS and component validation for `raisely deploy` (with `--no-validate`) and per-save validation for `raisely start`.
+- Improved `raisely local` resilience by serving the last successful CSS when compilation fails, removing the 5-second retry loop, and removing process exit on transpiler 401 responses.
+- Removed v1 compatibility read paths; v2 commands now require the v2 layout.
+
 # 1.8.3
 - Fix redirects for `raisely local`
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For more about Raisely, see [https://raisely.com](https://raisely.com)
 
 ## Overview
 
-The Raisely CLI allows for fast and easy development on the Raisely platform. The CLI allows you to connect a directory on your local computer to a Raisely account. With the CLI you can update campaign stylesheets, edit and create custom React components, and edit page layout JSON under `pages/`.
+The Raisely CLI allows for fast and easy development on the Raisely platform. The CLI allows you to connect a directory on your local computer to a Raisely account. With the CLI you can update campaign stylesheets, edit and create custom React components, and edit page layout JSON under `campaigns/<campaign-path>/pages/`.
 
 The CLI is built on Node.js, so you'll need Node.js installed to use it.
 
@@ -25,6 +25,19 @@ For other issues, [submit a support ticket](mailto:support@raisely.com).
 1. Install the CLI globally: `npm install @raisely/cli -g`
 2. Go into your working directory and run: `raisely init`
 
+`raisely init` writes the v2 project layout:
+
+```text
+campaigns/
+  <campaign-path>/
+    pages/
+      home.json
+    stylesheets/
+      main.scss
+components/
+  CustomHeader.js
+```
+
 ## Commands
 
 -   `raisely init` - start a new Raisely project and sync your campaigns
@@ -34,10 +47,12 @@ For other issues, [submit a support ticket](mailto:support@raisely.com).
 -   `raisely logout` - revoke the current access token when possible and clear keychain storage for this org
 -   `raisely update` - update local copies of styles, components, and pages from the API
 -   `raisely update --force` - same as above without the confirmation prompt (for CI/scripts)
+-   `raisely migrate` - migrate an existing repo from the legacy layout to the v2 layout
 -   `raisely create [name]` - create a new custom component, optionally add the component name to the command (otherwise you will be asked for one)
--   `raisely start` - starts watching for and uploading changes to styles and components
+-   `raisely start` - starts watching for and uploading validated changes to styles and components
 -   `raisely deploy` - deploy your local code to Raisely (styles, components, and pages)
--   `raisely local` - work locally on a Raisely campaign without syncing changes up (includes local page JSON overrides when `pages/` is present)
+-   `raisely deploy --no-validate` - deploy without running pre-flight validation first
+-   `raisely local` - work locally on a Raisely campaign without syncing changes up (includes local page JSON overrides from `campaigns/<campaign-path>/pages/` when present)
 -   `raisely local --uuid <uuid>` - open a specific campaign by UUID, skipping the picker
 -   `raisely local --port <port>` - run the local development server on a custom port instead of `8015`
 


### PR DESCRIPTION
## What Changed
- Added a `2.0.0` changelog entry that documents the v2 layout change, `raisely migrate`, deploy/start validation behavior, `--no-validate`, and `raisely local` CSS resilience updates.
- Updated README path references and examples to the v2 layout under `campaigns/<campaign-path>/...`.
- Added command documentation for `raisely migrate` and `raisely deploy --no-validate`, and clarified validation behavior in `raisely start` and `raisely local`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates (README/CHANGELOG) with no code, dependency, or deployment configuration changes.
> 
> **Overview**
> Documents the v2 CLI release by adding a `2.0.0` entry to `CHANGELOG.md`, including the breaking project layout change, the new `raisely migrate` command, new validation behavior for `raisely deploy`/`raisely start` (plus `--no-validate`), and `raisely local` resilience updates.
> 
> Updates `README.md` to reference the new v2 directory layout under `campaigns/<campaign-path>/...`, adds an example layout, and expands command docs for `raisely migrate`, `raisely deploy --no-validate`, and the validation behavior of `raisely start`/`raisely local`.
> 
> ## Risk Assessment (Framework v2.0)
> 
> | Dimension | Tier | Score | Rationale |
> |---|---|---|---|
> | Security | 1 | Low | No findings |
> | Sensitive domains | 1 | Low | None (docs only) |
> | Data integrity | 1 | Low | No data access changes |
> | Deployment | 1 | Low | No infra/config changes |
> | Scope | 2 | Low | Small, documentation-only edits |
> | Architecture | 2 | Low | No code changes |
> | Feature flags | 2 | Low | Not applicable (docs only) |
> | Dependencies | 2 | Low | No changes |
> 
> ### Findings
> 
> | # | Finding | Status | Resolution |
> |---|---|---|---|
> 
> **Outstanding findings: 0**
> **Overall risk: LOW**
> **Decision: APPROVED**
> **Rationale:** Docs-only changes with no impact on runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f77176eda36bffb8ad8f4d8b380f717784070f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->