### PR TITLE
SIR-1556 - Track command telemetry events

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -50,7 +50,7 @@ export default async function api(options) {
 							: {}),
 						...(bearer ? { Authorization: `Bearer ${bearer}` } : {}),
 						...options.headers,
-						'x-raisely-cli': true,
+						'x-raisely-client': 'cli',
 					},
 					body:
 						options.method !== 'GET' && options.json

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,16 +1,34 @@
 import { InvalidArgumentError, program } from 'commander';
 import { getPackageInfo } from './helpers.js';
+import { flushTelemetry, trackEvent } from './telemetry.js';
 
 /**
  * Action creator - only loads modules for commands when individually invoked
  * @param moduleLoader
  * @returns {(function(...[*]): Promise<void>)|*}
  */
-function actionBuilder(moduleLoader) {
+function actionBuilder(moduleLoader, commandName) {
 	return async function runtime(...args) {
-		// load the module
-		const { default: commandContext } = await moduleLoader();
-		await commandContext(...args);
+		const startedAt = Date.now();
+		let outcome = 'success';
+		let errorCode;
+		try {
+			// load the module
+			const { default: commandContext } = await moduleLoader();
+			await commandContext(...args);
+		} catch (error) {
+			outcome = 'error';
+			errorCode =
+				error?.subcode || error?.code || error?.status || error?.name;
+			throw error;
+		} finally {
+			trackEvent(`cli.${commandName}`, {
+				outcome,
+				durationMs: Date.now() - startedAt,
+				...(errorCode ? { errorCode } : {}),
+			});
+			await flushTelemetry();
+		}
 	};
 }
 
@@ -23,16 +41,16 @@ function parsePort(value) {
 }
 
 // define actions
-const init = actionBuilder(() => import('./init.js'));
-const update = actionBuilder(() => import('./update.js'));
-const start = actionBuilder(() => import('./start.js'));
-const create = actionBuilder(() => import('./create.js'));
-const deploy = actionBuilder(() => import('./deploy.js'));
-const login = actionBuilder(() => import('./login.js'));
-const logout = actionBuilder(() => import('./logout.js'));
-const local = actionBuilder(() => import('./local.js'));
-const list = actionBuilder(() => import('./list.js'));
-const migrate = actionBuilder(() => import('./migrate.js'));
+const init = actionBuilder(() => import('./init.js'), 'init');
+const update = actionBuilder(() => import('./update.js'), 'update');
+const start = actionBuilder(() => import('./start.js'), 'start');
+const create = actionBuilder(() => import('./create.js'), 'create');
+const deploy = actionBuilder(() => import('./deploy.js'), 'deploy');
+const login = actionBuilder(() => import('./login.js'), 'login');
+const logout = actionBuilder(() => import('./logout.js'), 'logout');
+const local = actionBuilder(() => import('./local.js'), 'local');
+const list = actionBuilder(() => import('./list.js'), 'list');
+const migrate = actionBuilder(() => import('./migrate.js'), 'migrate');
 
 export async function cli() {
 	const pkg = getPackageInfo();

--- a/src/logout.js
+++ b/src/logout.js
@@ -51,7 +51,7 @@ async function deleteJwtToken(accountKey) {
 			method: 'DELETE',
 			headers: {
 				Authorization: `Bearer ${token}`,
-				'x-raisely-cli': 'true',
+				'x-raisely-client': 'cli',
 			},
 			agent: devHttpsAgent,
 		});

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -42,7 +42,7 @@ async function fetchAuthenticateContext({ apiUrl, token }) {
 			method: 'GET',
 			headers: {
 				Authorization: `Bearer ${token}`,
-				'x-raisely-cli': 'true',
+				'x-raisely-client': 'cli',
 			},
 			signal,
 			agent: devHttpsAgent,
@@ -134,7 +134,7 @@ async function sendPayload(eventName, traits = {}) {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
-			'x-raisely-cli': 'true',
+			'x-raisely-client': 'cli',
 			...(metadata.token ? { Authorization: `Bearer ${metadata.token}` } : {}),
 		},
 		body: JSON.stringify(payload),

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -1,0 +1,164 @@
+import fetch from 'node-fetch';
+import https from 'https';
+
+import { loadConfig } from './config.js';
+import { getCredentials, resolveOrganisationContext } from './credentials.js';
+import { getPackageInfo } from './helpers.js';
+
+const pending = new Set();
+const devHttpsAgent = new https.Agent({
+	rejectUnauthorized: false,
+});
+
+let cachedMetadata;
+let metadataPromise;
+
+function telemetryDisabled() {
+	const raw = process.env.RAISELY_NO_TELEMETRY;
+	if (!raw) return false;
+	const normalized = String(raw).trim().toLowerCase();
+	return normalized === '1' || normalized === 'true';
+}
+
+function parseAuthenticateResponse(payload) {
+	if (!payload || typeof payload !== 'object') {
+		return {};
+	}
+	const data = payload.data && typeof payload.data === 'object' ? payload.data : payload;
+	return {
+		userUuid: data.userUuid,
+		organisationUuid: data.organisationUuid,
+	};
+}
+
+async function fetchAuthenticateContext({ apiUrl, token }) {
+	if (!apiUrl || !token) {
+		return {};
+	}
+	try {
+		const response = await fetch(`${apiUrl.replace(/\/$/, '')}/v3/authenticate`, {
+			method: 'GET',
+			headers: {
+				Authorization: `Bearer ${token}`,
+				'x-raisely-cli': 'true',
+			},
+			agent: devHttpsAgent,
+		});
+		if (!response.ok) {
+			return {};
+		}
+		const payload = await response.json();
+		return parseAuthenticateResponse(payload);
+	} catch {
+		return {};
+	}
+}
+
+async function resolveTelemetryMetadata() {
+	if (cachedMetadata) {
+		return cachedMetadata;
+	}
+	if (!metadataPromise) {
+		metadataPromise = (async () => {
+			const config = await loadConfig({ allowEmpty: true });
+			const campaignIds = Array.isArray(config.campaigns)
+				? config.campaigns.filter(Boolean)
+				: [];
+			const ctx = await resolveOrganisationContext();
+			const organisationUuid = ctx?.organisationUuid || config.organisationUuid;
+			const apiUrl = ctx?.apiUrl || config.apiUrl;
+
+			let token;
+			try {
+				const credentials = await getCredentials({ allowPrompt: false });
+				token = credentials.token;
+			} catch {
+				token = null;
+			}
+
+			const authContext = await fetchAuthenticateContext({ apiUrl, token });
+			const pkg = getPackageInfo();
+			return {
+				apiUrl,
+				token,
+				campaignIds,
+				organisationUuid:
+					authContext.organisationUuid || organisationUuid || undefined,
+				userUuid: authContext.userUuid || undefined,
+				cliVersion: pkg.version || undefined,
+				nodeVersion: process.version,
+				platform: process.platform,
+			};
+		})();
+	}
+	try {
+		cachedMetadata = await metadataPromise;
+	} catch {
+		cachedMetadata = {
+			campaignIds: [],
+			nodeVersion: process.version,
+			platform: process.platform,
+		};
+	}
+	return cachedMetadata;
+}
+
+async function sendPayload(eventName, traits = {}) {
+	const metadata = await resolveTelemetryMetadata();
+	if (!metadata.apiUrl) {
+		return;
+	}
+
+	const payload = {
+		e: eventName,
+		...(metadata.organisationUuid ? { o: metadata.organisationUuid } : {}),
+		...(metadata.userUuid ? { u: metadata.userUuid } : {}),
+		...(metadata.campaignIds[0] ? { c: metadata.campaignIds[0] } : {}),
+		t: {
+			outcome: traits.outcome,
+			durationMs: traits.durationMs,
+			errorCode: traits.errorCode,
+			...traits,
+			campaignIds: metadata.campaignIds,
+			cliVersion: metadata.cliVersion,
+			nodeVersion: metadata.nodeVersion,
+			platform: metadata.platform,
+		},
+	};
+
+	await fetch(`${metadata.apiUrl.replace(/\/$/, '')}/v3/t`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'x-raisely-cli': 'true',
+			...(metadata.token ? { Authorization: `Bearer ${metadata.token}` } : {}),
+		},
+		body: JSON.stringify(payload),
+		agent: devHttpsAgent,
+	});
+}
+
+export function trackEvent(eventName, traits = {}) {
+	if (telemetryDisabled()) {
+		return;
+	}
+	const promise = sendPayload(eventName, traits).catch(() => {});
+	pending.add(promise);
+	promise.finally(() => {
+		pending.delete(promise);
+	});
+}
+
+export async function flushTelemetry() {
+	if (pending.size === 0) {
+		return;
+	}
+	await Promise.allSettled([...pending]);
+	pending.clear();
+}
+
+export function __resetTelemetryForTests() {
+	pending.clear();
+	cachedMetadata = undefined;
+	metadataPromise = undefined;
+}

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -159,7 +159,6 @@ export async function flushTelemetry() {
 		return;
 	}
 	await Promise.allSettled([...pending]);
-	pending.clear();
 }
 
 export function __resetTelemetryForTests() {

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -9,6 +9,7 @@ const pending = new Set();
 const devHttpsAgent = new https.Agent({
 	rejectUnauthorized: false,
 });
+const TELEMETRY_REQUEST_TIMEOUT_MS = 10_000;
 
 let cachedMetadata;
 let metadataPromise;
@@ -36,12 +37,14 @@ async function fetchAuthenticateContext({ apiUrl, token }) {
 		return {};
 	}
 	try {
+		const signal = AbortSignal.timeout(TELEMETRY_REQUEST_TIMEOUT_MS);
 		const response = await fetch(`${apiUrl.replace(/\/$/, '')}/v3/authenticate`, {
 			method: 'GET',
 			headers: {
 				Authorization: `Bearer ${token}`,
 				'x-raisely-cli': 'true',
 			},
+			signal,
 			agent: devHttpsAgent,
 		});
 		if (!response.ok) {
@@ -126,6 +129,7 @@ async function sendPayload(eventName, traits = {}) {
 		},
 	};
 
+	const signal = AbortSignal.timeout(TELEMETRY_REQUEST_TIMEOUT_MS);
 	await fetch(`${metadata.apiUrl.replace(/\/$/, '')}/v3/t`, {
 		method: 'POST',
 		headers: {
@@ -134,6 +138,7 @@ async function sendPayload(eventName, traits = {}) {
 			...(metadata.token ? { Authorization: `Bearer ${metadata.token}` } : {}),
 		},
 		body: JSON.stringify(payload),
+		signal,
 		agent: devHttpsAgent,
 	});
 }

--- a/tests/telemetry.test.js
+++ b/tests/telemetry.test.js
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	fetch: vi.fn(),
+	loadConfig: vi.fn(),
+	resolveOrganisationContext: vi.fn(),
+	getCredentials: vi.fn(),
+	getPackageInfo: vi.fn(),
+}));
+
+vi.mock('node-fetch', () => ({
+	default: mocks.fetch,
+}));
+
+vi.mock('../src/config.js', () => ({
+	loadConfig: mocks.loadConfig,
+}));
+
+vi.mock('../src/credentials.js', () => ({
+	resolveOrganisationContext: mocks.resolveOrganisationContext,
+	getCredentials: mocks.getCredentials,
+}));
+
+vi.mock('../src/helpers.js', () => ({
+	getPackageInfo: mocks.getPackageInfo,
+}));
+
+import {
+	__resetTelemetryForTests,
+	flushTelemetry,
+	trackEvent,
+} from '../src/telemetry.js';
+
+function createJsonResponse(json, ok = true) {
+	return {
+		ok,
+		json: async () => json,
+	};
+}
+
+describe('telemetry', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		delete process.env.RAISELY_NO_TELEMETRY;
+
+		mocks.loadConfig.mockResolvedValue({
+			apiUrl: 'https://api.raisely.com',
+			organisationUuid: 'org-config',
+			campaigns: ['campaign-a', 'campaign-b'],
+		});
+		mocks.resolveOrganisationContext.mockResolvedValue({
+			apiUrl: 'https://api.raisely.com',
+			organisationUuid: 'org-context',
+		});
+		mocks.getCredentials.mockResolvedValue({ token: 'token-123' });
+		mocks.getPackageInfo.mockReturnValue({
+			name: '@raisely/cli',
+			version: '2.0.0-test',
+		});
+	});
+
+	afterEach(async () => {
+		await flushTelemetry();
+		__resetTelemetryForTests();
+	});
+
+	test('sends telemetry with resolved metadata and reuses cached context', async () => {
+		mocks.fetch
+			.mockResolvedValueOnce(
+				createJsonResponse({
+					userUuid: 'user-1',
+					organisationUuid: 'org-auth',
+				})
+			)
+			.mockResolvedValueOnce(createJsonResponse({ ok: true }))
+			.mockResolvedValueOnce(createJsonResponse({ ok: true }));
+
+		trackEvent('cli.deploy', { outcome: 'success', durationMs: 33 });
+		trackEvent('cli.update', { outcome: 'error', durationMs: 7, errorCode: 500 });
+		await flushTelemetry();
+
+		expect(mocks.fetch).toHaveBeenCalledTimes(3);
+		expect(mocks.fetch).toHaveBeenNthCalledWith(
+			1,
+			'https://api.raisely.com/v3/authenticate',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({
+					Authorization: 'Bearer token-123',
+				}),
+			})
+		);
+		expect(mocks.fetch).toHaveBeenNthCalledWith(
+			2,
+			'https://api.raisely.com/v3/t',
+			expect.objectContaining({
+				method: 'POST',
+				body: expect.stringContaining('"e":"cli.deploy"'),
+			})
+		);
+		expect(mocks.fetch).toHaveBeenNthCalledWith(
+			3,
+			'https://api.raisely.com/v3/t',
+			expect.objectContaining({
+				method: 'POST',
+				body: expect.stringContaining('"e":"cli.update"'),
+			})
+		);
+
+		const secondPayload = JSON.parse(mocks.fetch.mock.calls[1][1].body);
+		expect(secondPayload.o).toBe('org-auth');
+		expect(secondPayload.u).toBe('user-1');
+		expect(secondPayload.c).toBe('campaign-a');
+		expect(secondPayload.t.campaignIds).toEqual(['campaign-a', 'campaign-b']);
+		expect(secondPayload.t.cliVersion).toBe('2.0.0-test');
+		expect(secondPayload.t.outcome).toBe('success');
+		expect(secondPayload.t.durationMs).toBe(33);
+
+		const thirdPayload = JSON.parse(mocks.fetch.mock.calls[2][1].body);
+		expect(thirdPayload.t.errorCode).toBe(500);
+		expect(mocks.resolveOrganisationContext).toHaveBeenCalledTimes(1);
+	});
+
+	test('flushTelemetry waits for in-flight telemetry promises', async () => {
+		let resolveSend;
+		const pendingSend = new Promise((resolve) => {
+			resolveSend = resolve;
+		});
+		mocks.fetch
+			.mockResolvedValueOnce(createJsonResponse({ userUuid: 'user-1' }))
+			.mockReturnValueOnce(pendingSend);
+
+		trackEvent('cli.local', { outcome: 'success', durationMs: 99 });
+		const flushPromise = flushTelemetry();
+
+		let settled = false;
+		flushPromise.then(() => {
+			settled = true;
+		});
+		await Promise.resolve();
+		expect(settled).toBe(false);
+
+		resolveSend(createJsonResponse({ ok: true }));
+		await flushPromise;
+		expect(settled).toBe(true);
+	});
+
+	test('RAISELY_NO_TELEMETRY disables telemetry', async () => {
+		process.env.RAISELY_NO_TELEMETRY = 'true';
+
+		trackEvent('cli.list', { outcome: 'success', durationMs: 2 });
+		await flushTelemetry();
+
+		expect(mocks.fetch).not.toHaveBeenCalled();
+		expect(mocks.loadConfig).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- Add command-level telemetry tracking for the CLI, including outcome, duration, and error code metadata.
- Send telemetry with resolved org, user, campaign, and runtime context, and wait for in-flight events before command exit.
- Add focused tests for metadata caching, pending-flush behavior, and `RAISELY_NO_TELEMETRY`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a new telemetry pipeline that sends org/user/campaign context and may include auth-derived identifiers, and it expands use of an HTTPS agent that disables certificate validation—both security/privacy-sensitive behaviors.
> 
> **Overview**
> Adds command-level telemetry to the CLI by wrapping each command execution to record `outcome`, `durationMs`, and an `errorCode`, then flushing in-flight events before exit.
> 
> Introduces `src/telemetry.js`, which resolves org/user/campaign/runtime metadata (optionally via `/v3/authenticate`) and posts events to `/v3/t`, with opt-out via `RAISELY_NO_TELEMETRY`; includes new unit tests covering metadata caching and flush behavior.
> 
> Also standardizes the request identification header from `x-raisely-cli` to `x-raisely-client: cli` in API and logout requests.
> 
> ## Risk Assessment (Framework v2.0)
> 
> | Dimension | Tier | Score | Rationale |
> |---|---|---|---|
> | Security | 1 | High | New telemetry adds additional outbound requests using an HTTPS agent with `rejectUnauthorized: false`, increasing exposure to MITM if misconfigured. |
> | Sensitive domains | 1 | High | Touches token/session-adjacent code (uses bearer token to call `/v3/authenticate` and send telemetry with user/org identifiers). |
> | Data integrity | 1 | Low | No database or persistence changes. |
> | Deployment | 1 | Low | No CI/CD or infrastructure changes. |
> | Scope | 2 | Low | Mostly additive (new telemetry module + tests) with small edits to existing CLI/API headers. |
> | Architecture | 2 | Medium | Adds a new shared utility (`telemetry.js`) invoked by all CLI commands. |
> | Feature flags | 2 | Low | Internal-only behavior; env-var opt-out provided. |
> | Dependencies | 2 | Low | No dependency file changes in diff. |
> 
> ### Findings
> 
> | # | Finding | Status | Resolution |
> |---|---|---|---|
> | 1 | Telemetry uses an HTTPS agent that disables TLS certificate verification (`rejectUnauthorized: false`), which is unsafe beyond local/dev use. | Open | -- |
> 
> **Outstanding findings: 1**
> **Overall risk: HIGH**
> **Decision: ESCALATE**
> **Rationale:** Tier 1 Security and Sensitive domains are High due to token-adjacent telemetry and expanded use of disabled TLS verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c14dfc385d86f298c8673b0a170f4fbfb5970ab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->