### PR TITLE
SIR-1556 - Improve telemetry payload

### DIFF
--- a/src/logout.js
+++ b/src/logout.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import https from 'https';
 import ora from 'ora';
-import jwtDecode from 'jwt-decode';
+import { jwtDecode } from 'jwt-decode';
 import fetch from 'node-fetch';
 
 import { loadConfig, defaults, CONFIG_FILE, updateConfig } from './config.js';

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch';
 import https from 'https';
+import { randomUUID } from 'crypto';
 
 import { loadConfig } from './config.js';
 import { getCredentials, resolveOrganisationContext } from './credentials.js';
@@ -13,6 +14,15 @@ const TELEMETRY_REQUEST_TIMEOUT_MS = 10_000;
 
 let cachedMetadata;
 let metadataPromise;
+let sessionId = generateSessionId();
+
+function generateSessionId() {
+	try {
+		return randomUUID();
+	} catch {
+		return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+	}
+}
 
 function telemetryDisabled() {
 	const raw = process.env.RAISELY_NO_TELEMETRY;
@@ -113,11 +123,14 @@ async function sendPayload(eventName, traits = {}) {
 	}
 
 	const payload = {
-		e: eventName,
-		...(metadata.organisationUuid ? { o: metadata.organisationUuid } : {}),
-		...(metadata.userUuid ? { u: metadata.userUuid } : {}),
-		...(metadata.campaignIds[0] ? { c: metadata.campaignIds[0] } : {}),
-		t: {
+		event: eventName,
+		sessionId,
+		...(metadata.organisationUuid
+			? { organisationUuid: metadata.organisationUuid }
+			: {}),
+		...(metadata.userUuid ? { userUuid: metadata.userUuid } : {}),
+		...(metadata.campaignIds[0] ? { campaignUuid: metadata.campaignIds[0] } : {}),
+		traits: {
 			outcome: traits.outcome,
 			durationMs: traits.durationMs,
 			errorCode: traits.errorCode,
@@ -165,4 +178,5 @@ export function __resetTelemetryForTests() {
 	pending.clear();
 	cachedMetadata = undefined;
 	metadataPromise = undefined;
+	sessionId = generateSessionId();
 }

--- a/tests/telemetry.test.js
+++ b/tests/telemetry.test.js
@@ -95,7 +95,7 @@ describe('telemetry', () => {
 			'https://api.raisely.com/v3/t',
 			expect.objectContaining({
 				method: 'POST',
-				body: expect.stringContaining('"e":"cli.deploy"'),
+				body: expect.stringContaining('"event":"cli.deploy"'),
 			})
 		);
 		expect(mocks.fetch).toHaveBeenNthCalledWith(
@@ -103,21 +103,25 @@ describe('telemetry', () => {
 			'https://api.raisely.com/v3/t',
 			expect.objectContaining({
 				method: 'POST',
-				body: expect.stringContaining('"e":"cli.update"'),
+				body: expect.stringContaining('"event":"cli.update"'),
 			})
 		);
 
 		const secondPayload = JSON.parse(mocks.fetch.mock.calls[1][1].body);
-		expect(secondPayload.o).toBe('org-auth');
-		expect(secondPayload.u).toBe('user-1');
-		expect(secondPayload.c).toBe('campaign-a');
-		expect(secondPayload.t.campaignIds).toEqual(['campaign-a', 'campaign-b']);
-		expect(secondPayload.t.cliVersion).toBe('2.0.0-test');
-		expect(secondPayload.t.outcome).toBe('success');
-		expect(secondPayload.t.durationMs).toBe(33);
+		expect(secondPayload.organisationUuid).toBe('org-auth');
+		expect(secondPayload.userUuid).toBe('user-1');
+		expect(secondPayload.campaignUuid).toBe('campaign-a');
+		expect(secondPayload.sessionId).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+		);
+		expect(secondPayload.traits.campaignIds).toEqual(['campaign-a', 'campaign-b']);
+		expect(secondPayload.traits.cliVersion).toBe('2.0.0-test');
+		expect(secondPayload.traits.outcome).toBe('success');
+		expect(secondPayload.traits.durationMs).toBe(33);
 
 		const thirdPayload = JSON.parse(mocks.fetch.mock.calls[2][1].body);
-		expect(thirdPayload.t.errorCode).toBe(500);
+		expect(thirdPayload.traits.errorCode).toBe(500);
+		expect(thirdPayload.sessionId).toBe(secondPayload.sessionId);
 		expect(mocks.resolveOrganisationContext).toHaveBeenCalledTimes(1);
 	});
 


### PR DESCRIPTION
## Summary

- Update CLI telemetry payload field names from shorthand to descriptive keys.
- Add a generated `sessionId` to telemetry events so events from one CLI run can be correlated.
- Fix `logout` runtime failure by switching `jwt-decode` import to the v4 named export.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies telemetry event schema (including a new `sessionId`) and adjusts logout JWT decoding import; low security exposure but downstream telemetry ingestion/analytics may break if not updated for the new payload shape.
> 
> **Overview**
> Improves CLI telemetry by switching from shorthand fields to descriptive keys, moving event metadata (`organisationUuid`, `userUuid`, `campaignUuid`) and event `traits` into a clearer top-level payload, and adding a per-run `sessionId` to correlate events.
> 
> Fixes a `logout` runtime issue by updating the `jwt-decode` import to use the v4 named export, and updates telemetry tests to validate the new payload shape and `sessionId` reuse across events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9d8be483914e0331941bf0d3782eff61e78433d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->