### PR TITLE
chore: bump version to 2.0.0-alpha.3 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@raisely/cli",
-	"version": "2.0.0-alpha.2",
+	"version": "2.0.0-alpha.3",
 	"description": "Raisely CLI for local development",
 	"main": "./src/cli.js",
 	"type": "module",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single version field change with no code or dependency updates in the diff.
> 
> **Overview**
> Bumps the published **`@raisely/cli`** semver in **`package.json`** from **`2.0.0-alpha.2`** to **`2.0.0-alpha.3`**. No runtime, CLI, or dependency changes are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 493bc04b80085deaf6141f32496f9c3ad790846a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->