### PR TITLE
SIR-1655: Add `raisely media list` and `raisely media delete`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ components/
 -   `raisely media list --organisation <uuid>` - list media for an organisation by UUID
 -   `raisely media list --json` - output the media array as JSON instead of a table
 -   `raisely media delete <uuid>` - delete a media asset by UUID (no confirmation prompt)
+-   `raisely media upload <file-or-url>` - upload a local file or a public URL as a media asset; falls back to the first campaign in `.raisely.json` when no `--campaign` is passed
+-   `raisely media upload <file-or-url> --campaign <slug>` - upload to a specific campaign
+-   `raisely media upload <file-or-url> --organisation <uuid>` - upload to an organisation
+-   `raisely media upload <file-or-url> --force` - skip the confirmation prompt (required for non-interactive/agent use)
+-   `raisely media upload <file-or-url> --json` - skip the confirmation prompt and output the result as JSON
 
 ### Custom public host (`raisely local`)
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ components/
 -   `raisely local` - work locally on a Raisely campaign without syncing changes up (includes local page JSON overrides from `campaigns/<campaign-path>/pages/` when present)
 -   `raisely local --uuid <uuid>` - open a specific campaign by UUID, skipping the picker
 -   `raisely local --port <port>` - run the local development server on a custom port instead of `8015`
+-   `raisely media list` - list all media assets for a campaign or organisation; falls back to the first campaign in `.raisely.json` when no flag is passed
+-   `raisely media list --campaign <slug>` - list media for a specific campaign by path/slug
+-   `raisely media list --organisation <uuid>` - list media for an organisation by UUID
+-   `raisely media list --json` - output the media array as JSON instead of a table
+-   `raisely media delete <uuid>` - delete a media asset by UUID (no confirmation prompt)
 
 ### Custom public host (`raisely local`)
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"commander": "13.1.0",
 		"express": "5.2.1",
 		"folder-hash": "4.1.2",
+		"form-data": "4.0.6",
 		"fzstd": "0.1.1",
 		"glob": "8.1.0",
 		"glob-promise": "6.0.7",

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -15,6 +15,7 @@ const devHttpsAgent = new https.Agent({
 
 function getResponseContentType(response) {
 	const rawResponseContentType = response.headers.get('Content-Type');
+	if (!rawResponseContentType) return '';
 	const [contentType] = rawResponseContentType.split(';');
 	return contentType;
 }
@@ -43,7 +44,7 @@ export default async function api(options) {
 				const response = await fetch(fetchUrl, {
 					method: options.method || 'GET',
 					headers: {
-						...(isJson
+						...(isJson && !options.formData
 							? {
 									'Content-Type': 'application/json',
 							  }
@@ -53,8 +54,12 @@ export default async function api(options) {
 						'x-raisely-client': 'cli',
 					},
 					body:
-						options.method !== 'GET' && options.json
-							? JSON.stringify(options.json)
+						options.method !== 'GET'
+							? (options.rawBody ??
+							  options.formData ??
+							  (options.json
+									? JSON.stringify(options.json)
+									: undefined))
 							: undefined,
 					agent: config.apiUrl ? devHttpsAgent : undefined,
 				});

--- a/src/actions/media.js
+++ b/src/actions/media.js
@@ -1,4 +1,37 @@
+import fs from 'fs/promises';
+import path from 'path';
+
 import api from './api.js';
+
+const MIME_TYPES = {
+	'.png': 'image/png',
+	'.jpg': 'image/jpeg',
+	'.jpeg': 'image/jpeg',
+	'.gif': 'image/gif',
+	'.webp': 'image/webp',
+	'.svg': 'image/svg+xml',
+};
+
+function mimeTypeForFile(filePath) {
+	const ext = path.extname(filePath).toLowerCase();
+	return MIME_TYPES[ext] ?? 'application/octet-stream';
+}
+
+function buildMultipartBody(data, filename, mimeType) {
+	const boundary = `----RaiselyFormBoundary${Date.now().toString(16)}`;
+	const CRLF = '\r\n';
+	const head = Buffer.from(
+		`--${boundary}${CRLF}` +
+			`Content-Disposition: form-data; name="file"; filename="${filename}"${CRLF}` +
+			`Content-Type: ${mimeType}${CRLF}` +
+			CRLF
+	);
+	const tail = Buffer.from(`${CRLF}--${boundary}--${CRLF}`);
+	return {
+		body: Buffer.concat([head, data, tail]),
+		contentType: `multipart/form-data; boundary=${boundary}`,
+	};
+}
 
 export async function listCampaignMedia({ campaign }) {
 	return await api({
@@ -25,5 +58,49 @@ export async function deleteOrganisationMedia({ organisation, uuid }) {
 	return await api({
 		path: `/organisations/${organisation}/media/${uuid}`,
 		method: 'DELETE',
+	});
+}
+
+export async function uploadCampaignMedia({ campaign, file, url }) {
+	if (url) {
+		return await api({
+			path: `/campaigns/${campaign}/media`,
+			method: 'POST',
+			json: { url },
+		});
+	}
+	const data = await fs.readFile(file);
+	const { body, contentType } = buildMultipartBody(
+		data,
+		path.basename(file),
+		mimeTypeForFile(file)
+	);
+	return await api({
+		path: `/campaigns/${campaign}/media`,
+		method: 'POST',
+		rawBody: body,
+		headers: { 'Content-Type': contentType },
+	});
+}
+
+export async function uploadOrganisationMedia({ organisation, file, url }) {
+	if (url) {
+		return await api({
+			path: `/organisations/${organisation}/media`,
+			method: 'POST',
+			json: { url },
+		});
+	}
+	const data = await fs.readFile(file);
+	const { body, contentType } = buildMultipartBody(
+		data,
+		path.basename(file),
+		mimeTypeForFile(file)
+	);
+	return await api({
+		path: `/organisations/${organisation}/media`,
+		method: 'POST',
+		rawBody: body,
+		headers: { 'Content-Type': contentType },
 	});
 }

--- a/src/actions/media.js
+++ b/src/actions/media.js
@@ -1,0 +1,29 @@
+import api from './api.js';
+
+export async function listCampaignMedia({ campaign }) {
+	return await api({
+		path: `/campaigns/${campaign}/media`,
+		method: 'GET',
+	});
+}
+
+export async function listOrganisationMedia({ organisation }) {
+	return await api({
+		path: `/organisations/${organisation}/media`,
+		method: 'GET',
+	});
+}
+
+export async function deleteCampaignMedia({ campaign, uuid }) {
+	return await api({
+		path: `/campaigns/${campaign}/media/${uuid}`,
+		method: 'DELETE',
+	});
+}
+
+export async function deleteOrganisationMedia({ organisation, uuid }) {
+	return await api({
+		path: `/organisations/${organisation}/media/${uuid}`,
+		method: 'DELETE',
+	});
+}

--- a/src/actions/media.js
+++ b/src/actions/media.js
@@ -1,6 +1,8 @@
 import fs from 'fs/promises';
 import path from 'path';
 
+import FormData from 'form-data';
+
 import api from './api.js';
 
 const MIME_TYPES = {
@@ -15,22 +17,6 @@ const MIME_TYPES = {
 function mimeTypeForFile(filePath) {
 	const ext = path.extname(filePath).toLowerCase();
 	return MIME_TYPES[ext] ?? 'application/octet-stream';
-}
-
-function buildMultipartBody(data, filename, mimeType) {
-	const boundary = `----RaiselyFormBoundary${Date.now().toString(16)}`;
-	const CRLF = '\r\n';
-	const head = Buffer.from(
-		`--${boundary}${CRLF}` +
-			`Content-Disposition: form-data; name="file"; filename="${filename}"${CRLF}` +
-			`Content-Type: ${mimeType}${CRLF}` +
-			CRLF
-	);
-	const tail = Buffer.from(`${CRLF}--${boundary}--${CRLF}`);
-	return {
-		body: Buffer.concat([head, data, tail]),
-		contentType: `multipart/form-data; boundary=${boundary}`,
-	};
 }
 
 export async function listCampaignMedia({ campaign }) {
@@ -70,16 +56,16 @@ export async function uploadCampaignMedia({ campaign, file, url }) {
 		});
 	}
 	const data = await fs.readFile(file);
-	const { body, contentType } = buildMultipartBody(
-		data,
-		path.basename(file),
-		mimeTypeForFile(file)
-	);
+	const form = new FormData();
+	form.append('file', data, {
+		filename: path.basename(file),
+		contentType: mimeTypeForFile(file),
+	});
 	return await api({
 		path: `/campaigns/${campaign}/media`,
 		method: 'POST',
-		rawBody: body,
-		headers: { 'Content-Type': contentType },
+		rawBody: form,
+		headers: { 'Content-Type': form.getHeaders()['content-type'] },
 	});
 }
 
@@ -92,15 +78,15 @@ export async function uploadOrganisationMedia({ organisation, file, url }) {
 		});
 	}
 	const data = await fs.readFile(file);
-	const { body, contentType } = buildMultipartBody(
-		data,
-		path.basename(file),
-		mimeTypeForFile(file)
-	);
+	const form = new FormData();
+	form.append('file', data, {
+		filename: path.basename(file),
+		contentType: mimeTypeForFile(file),
+	});
 	return await api({
 		path: `/organisations/${organisation}/media`,
 		method: 'POST',
-		rawBody: body,
-		headers: { 'Content-Type': contentType },
+		rawBody: form,
+		headers: { 'Content-Type': form.getHeaders()['content-type'] },
 	});
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -56,6 +56,10 @@ const mediaDelete = actionBuilder(
 	() => import('./media/delete.js'),
 	'media.delete'
 );
+const mediaUpload = actionBuilder(
+	() => import('./media/upload.js'),
+	'media.upload'
+);
 
 export async function cli() {
 	const pkg = getPackageInfo();
@@ -173,6 +177,18 @@ export async function cli() {
 		.option('--organisation <uuid>', 'Organisation UUID')
 		.option('--json', 'Output result as JSON')
 		.action(mediaDelete);
+
+	media
+		.command('upload <file-or-url>')
+		.description('Upload a file or remote URL as a media asset')
+		.option(
+			'--campaign <slug>',
+			'Campaign path/slug (defaults to the first campaign in .raisely.json)'
+		)
+		.option('--organisation <uuid>', 'Organisation UUID')
+		.option('-f, --force', 'Skip the confirmation prompt')
+		.option('--json', 'Output result as JSON')
+		.action(mediaUpload);
 
 	// Make sure we show help after a bad command
 	program.showHelpAfterError();

--- a/src/cli.js
+++ b/src/cli.js
@@ -51,6 +51,11 @@ const logout = actionBuilder(() => import('./logout.js'), 'logout');
 const local = actionBuilder(() => import('./local.js'), 'local');
 const list = actionBuilder(() => import('./list.js'), 'list');
 const migrate = actionBuilder(() => import('./migrate.js'), 'migrate');
+const mediaList = actionBuilder(() => import('./media/list.js'), 'media.list');
+const mediaDelete = actionBuilder(
+	() => import('./media/delete.js'),
+	'media.delete'
+);
 
 export async function cli() {
 	const pkg = getPackageInfo();
@@ -139,6 +144,35 @@ export async function cli() {
 			'Migrate an existing repo from the v1 layout to the v2 layout (one-shot, idempotent)'
 		)
 		.action(migrate);
+
+	const media = program
+		.command('media')
+		.description('Manage campaign and organisation media assets')
+		.action(function () {
+			this.help();
+		});
+
+	media
+		.command('list')
+		.description('List media for a campaign or organisation')
+		.option(
+			'--campaign <slug>',
+			'Campaign path/slug (defaults to the first campaign in .raisely.json)'
+		)
+		.option('--organisation <uuid>', 'Organisation UUID')
+		.option('--json', 'Output as JSON')
+		.action(mediaList);
+
+	media
+		.command('delete <uuid>')
+		.description('Delete a media asset by UUID')
+		.option(
+			'--campaign <slug>',
+			'Campaign path/slug (defaults to the first campaign in .raisely.json)'
+		)
+		.option('--organisation <uuid>', 'Organisation UUID')
+		.option('--json', 'Output result as JSON')
+		.action(mediaDelete);
 
 	// Make sure we show help after a bad command
 	program.showHelpAfterError();

--- a/src/media/delete.js
+++ b/src/media/delete.js
@@ -1,0 +1,53 @@
+import ora from 'ora';
+
+import {
+	deleteCampaignMedia,
+	deleteOrganisationMedia,
+} from '../actions/media.js';
+import { loadConfig } from '../config.js';
+import { getCredentials, NotAuthenticatedError } from '../credentials.js';
+import { error } from '../helpers.js';
+
+export default async function mediaDelete(uuid, options = {}) {
+	try {
+		await getCredentials({ allowPrompt: false });
+	} catch (e) {
+		if (e instanceof NotAuthenticatedError) {
+			error(e);
+			return;
+		}
+		throw e;
+	}
+
+	let { campaign, organisation } = options;
+
+	if (!campaign && !organisation) {
+		const config = await loadConfig({ allowEmpty: true });
+		campaign = config.campaigns?.[0];
+	}
+
+	if (!campaign && !organisation) {
+		error('Provide --campaign <slug> or --organisation <uuid>');
+		return;
+	}
+
+	const loader = process.stdout.isTTY && !options.json
+		? ora(`Deleting media ${uuid}...`).start()
+		: null;
+
+	try {
+		if (organisation) {
+			await deleteOrganisationMedia({ organisation, uuid });
+		} else {
+			await deleteCampaignMedia({ campaign, uuid });
+		}
+
+		if (loader) {
+			loader.succeed(`Deleted ${uuid}`);
+		} else {
+			console.log(JSON.stringify({ success: true }));
+		}
+	} catch (e) {
+		error(e, loader);
+	}
+}

--- a/src/media/list.js
+++ b/src/media/list.js
@@ -57,30 +57,6 @@ export default async function mediaList(options = {}) {
 		return;
 	}
 
-	const uuidW = Math.max(
-		'uuid'.length,
-		...items.map((i) => (i.uuid ?? '').length)
-	);
-	const fileW = Math.max(
-		'file'.length,
-		...items.map((i) => (i.file ?? '').length)
-	);
-	const typeW = Math.max(
-		'type'.length,
-		...items.map((i) => (i.type ?? '').length)
-	);
-
-	console.log(
-		`${'uuid'.padEnd(uuidW)}  ${'file'.padEnd(fileW)}  ${'type'.padEnd(typeW)}  url`
-	);
-	console.log(
-		`${'-'.repeat(uuidW)}  ${'-'.repeat(fileW)}  ${'-'.repeat(typeW)}  ---`
-	);
-	for (const item of items) {
-		console.log(
-			`${(item.uuid ?? '').padEnd(uuidW)}  ${(item.file ?? '').padEnd(fileW)}  ${(item.type ?? '').padEnd(typeW)}  ${item.url ?? ''}`
-		);
-	}
-	console.log('');
+	console.table(items.map(({ uuid, file, type, url }) => ({ uuid, file, type, url })));
 	console.log(`${items.length} item${items.length === 1 ? '' : 's'}`);
 }

--- a/src/media/list.js
+++ b/src/media/list.js
@@ -1,0 +1,86 @@
+import ora from 'ora';
+
+import {
+	listCampaignMedia,
+	listOrganisationMedia,
+} from '../actions/media.js';
+import { loadConfig } from '../config.js';
+import { getCredentials, NotAuthenticatedError } from '../credentials.js';
+import { error } from '../helpers.js';
+
+export default async function mediaList(options = {}) {
+	try {
+		await getCredentials({ allowPrompt: false });
+	} catch (e) {
+		if (e instanceof NotAuthenticatedError) {
+			error(e);
+			return;
+		}
+		throw e;
+	}
+
+	let { campaign, organisation } = options;
+
+	if (!campaign && !organisation) {
+		const config = await loadConfig({ allowEmpty: true });
+		campaign = config.campaigns?.[0];
+	}
+
+	if (!campaign && !organisation) {
+		error('Provide --campaign <slug> or --organisation <uuid>');
+		return;
+	}
+
+	const isTTY = process.stdout.isTTY && !options.json;
+	const loader = isTTY ? ora('Loading media...').start() : null;
+
+	let response;
+	try {
+		response = organisation
+			? await listOrganisationMedia({ organisation })
+			: await listCampaignMedia({ campaign });
+		if (loader) loader.succeed();
+	} catch (e) {
+		error(e, loader);
+		return;
+	}
+
+	const items = response.data ?? [];
+
+	if (!isTTY) {
+		console.log(JSON.stringify(items, null, 2));
+		return;
+	}
+
+	if (items.length === 0) {
+		console.log('No media items found.');
+		return;
+	}
+
+	const uuidW = Math.max(
+		'uuid'.length,
+		...items.map((i) => (i.uuid ?? '').length)
+	);
+	const fileW = Math.max(
+		'file'.length,
+		...items.map((i) => (i.file ?? '').length)
+	);
+	const typeW = Math.max(
+		'type'.length,
+		...items.map((i) => (i.type ?? '').length)
+	);
+
+	console.log(
+		`${'uuid'.padEnd(uuidW)}  ${'file'.padEnd(fileW)}  ${'type'.padEnd(typeW)}  url`
+	);
+	console.log(
+		`${'-'.repeat(uuidW)}  ${'-'.repeat(fileW)}  ${'-'.repeat(typeW)}  ---`
+	);
+	for (const item of items) {
+		console.log(
+			`${(item.uuid ?? '').padEnd(uuidW)}  ${(item.file ?? '').padEnd(fileW)}  ${(item.type ?? '').padEnd(typeW)}  ${item.url ?? ''}`
+		);
+	}
+	console.log('');
+	console.log(`${items.length} item${items.length === 1 ? '' : 's'}`);
+}

--- a/src/media/upload.js
+++ b/src/media/upload.js
@@ -1,0 +1,101 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import inquirer from 'inquirer';
+import ora from 'ora';
+
+import {
+	uploadCampaignMedia,
+	uploadOrganisationMedia,
+} from '../actions/media.js';
+import { loadConfig } from '../config.js';
+import { getCredentials, NotAuthenticatedError } from '../credentials.js';
+import { error } from '../helpers.js';
+
+export default async function mediaUpload(fileOrUrl, options = {}) {
+	try {
+		await getCredentials({ allowPrompt: false });
+	} catch (e) {
+		if (e instanceof NotAuthenticatedError) {
+			error(e);
+			return;
+		}
+		throw e;
+	}
+
+	let { campaign, organisation, force } = options;
+	let campaignFromConfig = false;
+
+	if (!campaign && !organisation) {
+		const config = await loadConfig({ allowEmpty: true });
+		campaign = config.campaigns?.[0];
+		if (campaign) campaignFromConfig = true;
+	}
+
+	if (!campaign && !organisation) {
+		error('Provide --campaign <slug> or --organisation <uuid>');
+		return;
+	}
+
+	const isUrl =
+		fileOrUrl.startsWith('http://') || fileOrUrl.startsWith('https://');
+
+	if (!isUrl) {
+		try {
+			await fs.access(fileOrUrl);
+		} catch {
+			error(`File not found: ${fileOrUrl}`);
+			return;
+		}
+	}
+
+	if (!force && !options.json) {
+		const label = isUrl ? fileOrUrl : path.basename(fileOrUrl);
+		let target;
+		if (organisation) {
+			target = `organisation "${organisation}"`;
+		} else if (campaignFromConfig) {
+			target = `campaign "${campaign}" (from .raisely.json)`;
+		} else {
+			target = `campaign "${campaign}"`;
+		}
+
+		const { confirmed } = await inquirer.prompt([
+			{
+				type: 'confirm',
+				name: 'confirmed',
+				message: `Uploading to ${target} — are you sure you want to upload "${label}"?`,
+				default: false,
+			},
+		]);
+
+		if (!confirmed) {
+			console.log('Upload cancelled.');
+			return;
+		}
+	}
+
+	const isTTY = process.stdout.isTTY && !options.json;
+	const loader = isTTY ? ora('Uploading...').start() : null;
+
+	try {
+		const payload = isUrl ? { url: fileOrUrl } : { file: fileOrUrl };
+		const response = organisation
+			? await uploadOrganisationMedia({ organisation, ...payload })
+			: await uploadCampaignMedia({ campaign, ...payload });
+
+		const mediaUrl = response?.data?.url ?? response?.url ?? '';
+
+		if (loader) {
+			if (mediaUrl) {
+				loader.succeed(`Uploaded: ${mediaUrl}`);
+			} else {
+				loader.warn('Upload succeeded but no URL was returned.');
+			}
+		} else {
+			console.log(JSON.stringify(response?.data ?? response, null, 2));
+		}
+	} catch (e) {
+		error(e, loader);
+	}
+}


### PR DESCRIPTION
Scaffolds the `raisely media` command group with two subcommands for managing campaign and organisation media assets.

**`raisely media list [--campaign <slug>] [--organisation <uuid>]`**
- Returns the full media array for the given campaign or organisation
- Falls back to the first campaign in `.raisely.json` when `--campaign` is omitted and no `--organisation` is passed
- Prints a padded table in a terminal; outputs JSON when stdout is piped or `--json` is passed

**`raisely media delete <uuid> [--campaign <slug>] [--organisation <uuid>]`**
- Deletes a media asset by UUID with no confirmation prompt (UUID is explicit)
- Outputs a spinner + success message in a terminal; outputs `{"success":true}` when stdout is piped or `--json` is passed

**Both commands:**
- Use the existing auth flow: keychain → `RAISELY_TOKEN` → config token
- Are registered via the `actionBuilder` lazy-load pattern in `cli.js`
- Fall back to the first campaign in `.raisely.json` when `--campaign` is omitted

**Also includes:**
- `src/actions/media.js` — shared API helpers for campaign and organisation media list and delete
- `apps.js` scope fix in the API (SIR-1653 worktree): grants `upload.media` and `upload.orgMedia` under the `campaigns:update` OAuth scope so CLI tokens can reach the new endpoints

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Commands can delete or add remote media assets with no undo; delete is unprompted, so mistaken UUIDs or wrong `--campaign`/`--organisation` could cause unintended data loss.
> 
> **Overview**
> Adds a **`raisely media`** command group so the CLI can list, delete, and upload campaign or organisation media via the v3 API.
> 
> **`list`** and **`delete`** target `--campaign` or `--organisation`, defaulting to the first campaign in `.raisely.json` when neither is set. List shows a table in a TTY or JSON when piped/`--json`. Delete runs immediately by UUID (no prompt) and returns JSON success when non-interactive.
> 
> **`upload`** accepts a local path or `http(s)` URL, uses multipart for files (new **`form-data`** dependency), and supports `--force` / `--json` for scripts. Interactive uploads get a confirmation prompt.
> 
> Shared helpers live in **`src/actions/media.js`**. **`api.js`** now sends **`rawBody`** / form bodies without forcing `application/json`, and handles missing `Content-Type` on responses. README documents the new commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5415e7583b9fe102a913543e02d1bfe6a4b9f1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->