### PR TITLE
SIR-1656: Add `raisely media upload`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ components/
 -   `raisely media list --organisation <uuid>` - list media for an organisation by UUID
 -   `raisely media list --json` - output the media array as JSON instead of a table
 -   `raisely media delete <uuid>` - delete a media asset by UUID (no confirmation prompt)
+-   `raisely media upload <file-or-url>` - upload a local file or a public URL as a media asset; falls back to the first campaign in `.raisely.json` when no `--campaign` is passed
+-   `raisely media upload <file-or-url> --campaign <slug>` - upload to a specific campaign
+-   `raisely media upload <file-or-url> --organisation <uuid>` - upload to an organisation
+-   `raisely media upload <file-or-url> --force` - skip the confirmation prompt (required for non-interactive/agent use)
+-   `raisely media upload <file-or-url> --json` - skip the confirmation prompt and output the result as JSON
 
 ### Custom public host (`raisely local`)
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"commander": "13.1.0",
 		"express": "5.2.1",
 		"folder-hash": "4.1.2",
+		"form-data": "4.0.6",
 		"fzstd": "0.1.1",
 		"glob": "8.1.0",
 		"glob-promise": "6.0.7",

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -15,6 +15,7 @@ const devHttpsAgent = new https.Agent({
 
 function getResponseContentType(response) {
 	const rawResponseContentType = response.headers.get('Content-Type');
+	if (!rawResponseContentType) return '';
 	const [contentType] = rawResponseContentType.split(';');
 	return contentType;
 }
@@ -43,7 +44,7 @@ export default async function api(options) {
 				const response = await fetch(fetchUrl, {
 					method: options.method || 'GET',
 					headers: {
-						...(isJson
+						...(isJson && !options.formData
 							? {
 									'Content-Type': 'application/json',
 							  }
@@ -53,8 +54,12 @@ export default async function api(options) {
 						'x-raisely-client': 'cli',
 					},
 					body:
-						options.method !== 'GET' && options.json
-							? JSON.stringify(options.json)
+						options.method !== 'GET'
+							? (options.rawBody ??
+							  options.formData ??
+							  (options.json
+									? JSON.stringify(options.json)
+									: undefined))
 							: undefined,
 					agent: config.apiUrl ? devHttpsAgent : undefined,
 				});

--- a/src/actions/media.js
+++ b/src/actions/media.js
@@ -1,4 +1,37 @@
+import fs from 'fs/promises';
+import path from 'path';
+
 import api from './api.js';
+
+const MIME_TYPES = {
+	'.png': 'image/png',
+	'.jpg': 'image/jpeg',
+	'.jpeg': 'image/jpeg',
+	'.gif': 'image/gif',
+	'.webp': 'image/webp',
+	'.svg': 'image/svg+xml',
+};
+
+function mimeTypeForFile(filePath) {
+	const ext = path.extname(filePath).toLowerCase();
+	return MIME_TYPES[ext] ?? 'application/octet-stream';
+}
+
+function buildMultipartBody(data, filename, mimeType) {
+	const boundary = `----RaiselyFormBoundary${Date.now().toString(16)}`;
+	const CRLF = '\r\n';
+	const head = Buffer.from(
+		`--${boundary}${CRLF}` +
+			`Content-Disposition: form-data; name="file"; filename="${filename}"${CRLF}` +
+			`Content-Type: ${mimeType}${CRLF}` +
+			CRLF
+	);
+	const tail = Buffer.from(`${CRLF}--${boundary}--${CRLF}`);
+	return {
+		body: Buffer.concat([head, data, tail]),
+		contentType: `multipart/form-data; boundary=${boundary}`,
+	};
+}
 
 export async function listCampaignMedia({ campaign }) {
 	return await api({
@@ -25,5 +58,49 @@ export async function deleteOrganisationMedia({ organisation, uuid }) {
 	return await api({
 		path: `/organisations/${organisation}/media/${uuid}`,
 		method: 'DELETE',
+	});
+}
+
+export async function uploadCampaignMedia({ campaign, file, url }) {
+	if (url) {
+		return await api({
+			path: `/campaigns/${campaign}/media`,
+			method: 'POST',
+			json: { url },
+		});
+	}
+	const data = await fs.readFile(file);
+	const { body, contentType } = buildMultipartBody(
+		data,
+		path.basename(file),
+		mimeTypeForFile(file)
+	);
+	return await api({
+		path: `/campaigns/${campaign}/media`,
+		method: 'POST',
+		rawBody: body,
+		headers: { 'Content-Type': contentType },
+	});
+}
+
+export async function uploadOrganisationMedia({ organisation, file, url }) {
+	if (url) {
+		return await api({
+			path: `/organisations/${organisation}/media`,
+			method: 'POST',
+			json: { url },
+		});
+	}
+	const data = await fs.readFile(file);
+	const { body, contentType } = buildMultipartBody(
+		data,
+		path.basename(file),
+		mimeTypeForFile(file)
+	);
+	return await api({
+		path: `/organisations/${organisation}/media`,
+		method: 'POST',
+		rawBody: body,
+		headers: { 'Content-Type': contentType },
 	});
 }

--- a/src/actions/media.js
+++ b/src/actions/media.js
@@ -1,6 +1,8 @@
 import fs from 'fs/promises';
 import path from 'path';
 
+import FormData from 'form-data';
+
 import api from './api.js';
 
 const MIME_TYPES = {
@@ -15,22 +17,6 @@ const MIME_TYPES = {
 function mimeTypeForFile(filePath) {
 	const ext = path.extname(filePath).toLowerCase();
 	return MIME_TYPES[ext] ?? 'application/octet-stream';
-}
-
-function buildMultipartBody(data, filename, mimeType) {
-	const boundary = `----RaiselyFormBoundary${Date.now().toString(16)}`;
-	const CRLF = '\r\n';
-	const head = Buffer.from(
-		`--${boundary}${CRLF}` +
-			`Content-Disposition: form-data; name="file"; filename="${filename}"${CRLF}` +
-			`Content-Type: ${mimeType}${CRLF}` +
-			CRLF
-	);
-	const tail = Buffer.from(`${CRLF}--${boundary}--${CRLF}`);
-	return {
-		body: Buffer.concat([head, data, tail]),
-		contentType: `multipart/form-data; boundary=${boundary}`,
-	};
 }
 
 export async function listCampaignMedia({ campaign }) {
@@ -70,16 +56,16 @@ export async function uploadCampaignMedia({ campaign, file, url }) {
 		});
 	}
 	const data = await fs.readFile(file);
-	const { body, contentType } = buildMultipartBody(
-		data,
-		path.basename(file),
-		mimeTypeForFile(file)
-	);
+	const form = new FormData();
+	form.append('file', data, {
+		filename: path.basename(file),
+		contentType: mimeTypeForFile(file),
+	});
 	return await api({
 		path: `/campaigns/${campaign}/media`,
 		method: 'POST',
-		rawBody: body,
-		headers: { 'Content-Type': contentType },
+		rawBody: form,
+		headers: { 'Content-Type': form.getHeaders()['content-type'] },
 	});
 }
 
@@ -92,15 +78,15 @@ export async function uploadOrganisationMedia({ organisation, file, url }) {
 		});
 	}
 	const data = await fs.readFile(file);
-	const { body, contentType } = buildMultipartBody(
-		data,
-		path.basename(file),
-		mimeTypeForFile(file)
-	);
+	const form = new FormData();
+	form.append('file', data, {
+		filename: path.basename(file),
+		contentType: mimeTypeForFile(file),
+	});
 	return await api({
 		path: `/organisations/${organisation}/media`,
 		method: 'POST',
-		rawBody: body,
-		headers: { 'Content-Type': contentType },
+		rawBody: form,
+		headers: { 'Content-Type': form.getHeaders()['content-type'] },
 	});
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -56,6 +56,10 @@ const mediaDelete = actionBuilder(
 	() => import('./media/delete.js'),
 	'media.delete'
 );
+const mediaUpload = actionBuilder(
+	() => import('./media/upload.js'),
+	'media.upload'
+);
 
 export async function cli() {
 	const pkg = getPackageInfo();
@@ -173,6 +177,18 @@ export async function cli() {
 		.option('--organisation <uuid>', 'Organisation UUID')
 		.option('--json', 'Output result as JSON')
 		.action(mediaDelete);
+
+	media
+		.command('upload <file-or-url>')
+		.description('Upload a file or remote URL as a media asset')
+		.option(
+			'--campaign <slug>',
+			'Campaign path/slug (defaults to the first campaign in .raisely.json)'
+		)
+		.option('--organisation <uuid>', 'Organisation UUID')
+		.option('-f, --force', 'Skip the confirmation prompt')
+		.option('--json', 'Output result as JSON')
+		.action(mediaUpload);
 
 	// Make sure we show help after a bad command
 	program.showHelpAfterError();

--- a/src/media/upload.js
+++ b/src/media/upload.js
@@ -1,0 +1,101 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import inquirer from 'inquirer';
+import ora from 'ora';
+
+import {
+	uploadCampaignMedia,
+	uploadOrganisationMedia,
+} from '../actions/media.js';
+import { loadConfig } from '../config.js';
+import { getCredentials, NotAuthenticatedError } from '../credentials.js';
+import { error } from '../helpers.js';
+
+export default async function mediaUpload(fileOrUrl, options = {}) {
+	try {
+		await getCredentials({ allowPrompt: false });
+	} catch (e) {
+		if (e instanceof NotAuthenticatedError) {
+			error(e);
+			return;
+		}
+		throw e;
+	}
+
+	let { campaign, organisation, force } = options;
+	let campaignFromConfig = false;
+
+	if (!campaign && !organisation) {
+		const config = await loadConfig({ allowEmpty: true });
+		campaign = config.campaigns?.[0];
+		if (campaign) campaignFromConfig = true;
+	}
+
+	if (!campaign && !organisation) {
+		error('Provide --campaign <slug> or --organisation <uuid>');
+		return;
+	}
+
+	const isUrl =
+		fileOrUrl.startsWith('http://') || fileOrUrl.startsWith('https://');
+
+	if (!isUrl) {
+		try {
+			await fs.access(fileOrUrl);
+		} catch {
+			error(`File not found: ${fileOrUrl}`);
+			return;
+		}
+	}
+
+	if (!force && !options.json) {
+		const label = isUrl ? fileOrUrl : path.basename(fileOrUrl);
+		let target;
+		if (organisation) {
+			target = `organisation "${organisation}"`;
+		} else if (campaignFromConfig) {
+			target = `campaign "${campaign}" (from .raisely.json)`;
+		} else {
+			target = `campaign "${campaign}"`;
+		}
+
+		const { confirmed } = await inquirer.prompt([
+			{
+				type: 'confirm',
+				name: 'confirmed',
+				message: `Uploading to ${target} — are you sure you want to upload "${label}"?`,
+				default: false,
+			},
+		]);
+
+		if (!confirmed) {
+			console.log('Upload cancelled.');
+			return;
+		}
+	}
+
+	const isTTY = process.stdout.isTTY && !options.json;
+	const loader = isTTY ? ora('Uploading...').start() : null;
+
+	try {
+		const payload = isUrl ? { url: fileOrUrl } : { file: fileOrUrl };
+		const response = organisation
+			? await uploadOrganisationMedia({ organisation, ...payload })
+			: await uploadCampaignMedia({ campaign, ...payload });
+
+		const mediaUrl = response?.data?.url ?? response?.url ?? '';
+
+		if (loader) {
+			if (mediaUrl) {
+				loader.succeed(`Uploaded: ${mediaUrl}`);
+			} else {
+				loader.warn('Upload succeeded but no URL was returned.');
+			}
+		} else {
+			console.log(JSON.stringify(response?.data ?? response, null, 2));
+		}
+	} catch (e) {
+		error(e, loader);
+	}
+}


### PR DESCRIPTION
- Adds `raisely media upload <file-or-url>` subcommand to the existing `media` command group
- Auto-detects local file paths vs remote URLs by `http(s)://` prefix
- Local files are sent as `multipart/form-data` with the correct MIME type inferred from the file extension (PNG, JPG, GIF, WebP, SVG)
- Remote URLs are sent as JSON `{ url }` — the server fetches the image
- Confirmation prompt shows the resolved campaign or organisation name; when the campaign comes from `.raisely.json`, the prompt makes the source visible
- `--force` and `--json` both skip the confirmation prompt for non-interactive and agent use
- Adds `--campaign`, `--organisation`, `--force`, and `--json` flags
- Fixes a crash in `api.js` when an API response has no `Content-Type` header
- Builds the multipart body as a plain `Buffer` to avoid a `node-fetch` v3 / native `Blob` incompatibility on Node 18 that caused uploads to fail with "chunk ArrayBuffer is zero-length or detached"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New CLI feature and small HTTP client changes; no auth or payment logic touched.
> 
> **Overview**
> Adds **`raisely media upload <file-or-url>`** so users can push media to a campaign or organisation from the CLI, matching the existing `media list` / `delete` patterns.
> 
> Uploads accept either a **local path** (multipart with extension-based MIME types) or an **`http(s)` URL** (JSON `{ url }` for server-side fetch). Target resolution defaults to the first campaign in `.raisely.json`, with `--campaign`, `--organisation`, `--force`, and `--json` for scripting.
> 
> The shared **`api`** layer now supports **`rawBody` / `form-data`** without forcing `application/json`, and avoids crashing when responses omit a **`Content-Type`** header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f72e1ec925c18575a49bc9bad7a80adfc2a8908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->