### PR TITLE
fix: only deploy pages belonging to configured campaigns

### DIFF
--- a/src/deploy.js
+++ b/src/deploy.js
@@ -268,7 +268,7 @@ export default async function deploy(options = {}) {
 			continue;
 		}
 		if (
-			pageData.campaignUuid &&
+			!pageData.campaignUuid ||
 			!config.campaigns.includes(pageData.campaignUuid)
 		) {
 			continue;

--- a/tests/deploy.test.js
+++ b/tests/deploy.test.js
@@ -267,4 +267,69 @@ describe('deploy command', () => {
 		expect(mocks.uploadPage).not.toHaveBeenCalled();
 		expect(process.exitCode).toBeUndefined();
 	});
+
+	test('skips pages without campaignUuid', async () => {
+		mocks.fs.existsSync.mockImplementation(
+			(target) => target !== '/repo/components'
+		);
+		mocks.glob.mockResolvedValue(['campaigns/other/pages/home.json']);
+		mocks.fs.readFileSync.mockImplementation((target) => {
+			if (String(target).endsWith('home.json')) {
+				return JSON.stringify({ uuid: 'page-1', body: [] });
+			}
+			return '';
+		});
+
+		await deploy({});
+
+		expect(mocks.uploadPage).not.toHaveBeenCalled();
+	});
+
+	test('skips pages whose campaignUuid is not configured', async () => {
+		mocks.fs.existsSync.mockImplementation(
+			(target) => target !== '/repo/components'
+		);
+		mocks.glob.mockResolvedValue(['campaigns/other/pages/home.json']);
+		mocks.fs.readFileSync.mockImplementation((target) => {
+			if (String(target).endsWith('home.json')) {
+				return JSON.stringify({
+					uuid: 'page-1',
+					campaignUuid: 'some-other-campaign',
+					body: [],
+				});
+			}
+			return '';
+		});
+
+		await deploy({});
+
+		expect(mocks.uploadPage).not.toHaveBeenCalled();
+	});
+
+	test('uploads pages whose campaignUuid is configured', async () => {
+		mocks.fs.existsSync.mockImplementation(
+			(target) => target !== '/repo/components'
+		);
+		mocks.glob.mockResolvedValue(['campaigns/my-campaign/pages/home.json']);
+		mocks.fs.readFileSync.mockImplementation((target) => {
+			if (String(target).endsWith('home.json')) {
+				return JSON.stringify({
+					uuid: 'page-1',
+					campaignUuid: 'campaign-uuid',
+					body: [],
+				});
+			}
+			return '';
+		});
+
+		await deploy({});
+
+		expect(mocks.uploadPage).toHaveBeenCalledTimes(1);
+		expect(mocks.uploadPage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				uuid: 'page-1',
+				campaignUuid: 'campaign-uuid',
+			})
+		);
+	});
 });


### PR DESCRIPTION
## Summary

- Deploy uploaded any page JSON that had a `uuid`, so page files with `campaignUuid` omitted (or set to a campaign not in `config.campaigns`) were still PATCHed to the API. Deploy is meant to target only configured campaign UUIDs.
- The guard in `src/deploy.js` short-circuited on `pageData.campaignUuid && ...`, letting pages without the field fall through to upload.
- Now a page is skipped unless its `campaignUuid` is present **and** listed in `config.campaigns`.

## Changes

- `src/deploy.js`: tighten the page filter to require `campaignUuid` in `config.campaigns`.
- `tests/deploy.test.js`: add coverage for three cases via the real `deploy()` entry point:
  - page without `campaignUuid` is skipped
  - page with a non-configured `campaignUuid` is skipped
  - page with a configured `campaignUuid` is uploaded

## Behavior change

Pages that previously relied on omitting `campaignUuid` to get deployed will now be skipped. Page files should carry a `campaignUuid` (existing fixtures already do). This is the intended tightening.

## Test plan

- [x] `npx vitest run` — 84 passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deploy-time API uploads; repos with page files missing `campaignUuid` will silently stop updating those remote pages until fixtures are fixed.
> 
> **Overview**
> **Deploy no longer uploads page JSON unless `campaignUuid` is set and listed in `config.campaigns`.** The previous guard only skipped pages when a `campaignUuid` was present but not configured, so pages with the field omitted still reached `uploadPage`.
> 
> The page loop in `src/deploy.js` now treats missing or non-matching `campaignUuid` the same and skips those files. **Pages that depended on omitting `campaignUuid` to deploy will stop uploading** until their JSON includes a configured campaign UUID.
> 
> `tests/deploy.test.js` adds three integration-style cases through `deploy()`: skip without `campaignUuid`, skip with an unconfigured UUID, and upload when the UUID matches config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e26fb7401d6aa53cdacd969e760b4eafd70ba950. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->