### PR TITLE
docs: change log update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 
 # 1.8.4
-- 
+- Fix MFA login flow
 
 # 1.8.3
 - Fix redirects for `raisely local`

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -70,8 +70,17 @@ export default async function api(options) {
 				if (responseIsJSON && formatted) {
 					// if subcode, add this to error
 					const subcode = _.get(formatted, 'errors[0].subcode');
+					const twoFactorId = _.get(formatted, 'errors[0].twoFactorId');
+					const moreOtpMethods = _.get(formatted, 'errors[0].more.otpMethods');
+
 					if (subcode) {
 						error.subcode = subcode;
+					}
+					if (twoFactorId) {
+						error.twoFactorId = twoFactorId;
+					}
+					if (moreOtpMethods) {
+						error.moreOtpMethods = moreOtpMethods;
 					}
 				}
 

--- a/src/config.js
+++ b/src/config.js
@@ -107,6 +107,12 @@ export async function loadConfig({ allowEmpty = false } = {}) {
 			}
 		}
 	}
+
+	// Override the API URL if it's set in the environment variables
+	if (process.env.RAISELY_API_URL) {
+		config.apiUrl = process.env.RAISELY_API_URL;
+	}
+
 	return Object.assign({}, defaults, config);
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -129,7 +129,7 @@ export function error(e, loader) {
 }
 
 export function requiresMfa(e) {
-	return e.subcode && e.subcode.startsWith('MFA required');
+	return e.subcode && e.subcode.startsWith('MFA required') || e.twoFactorId;
 }
 
 export function getMfaStrategy(e) {
@@ -138,6 +138,8 @@ export function getMfaStrategy(e) {
 	const authType = subcodeArray[1];
 
 	return {
+		twoFactorId: e.twoFactorId,
+		moreOtpMethods: e.moreOtpMethods,
 		mfaType: authType,
 		// if authenticator, we need to know whether to offer authy as alternative
 		hasAuthy:  Boolean(

--- a/src/login.js
+++ b/src/login.js
@@ -9,23 +9,33 @@ import { log, error, informUpdate, requiresMfa, getMfaStrategy } from './helpers
 export async function doLogin(message) {
 	if (message) log(message, 'white');
 
-	// collect login details
-	const credentials = await inquirer.prompt([
-		{
-			type: 'input',
-			name: 'username',
-			message: 'Enter your email address',
-			validate: (value) =>
-				value.length ? true : 'Please enter your email address',
-		},
-		{
-			type: 'password',
-			message: 'Enter your password',
-			name: 'password',
-			validate: (value) =>
-				value.length ? true : 'Please enter a password',
-		},
-	]);
+	const debugCreds = {
+		username: process.env.DEBUG_USERNAME,
+		password: process.env.DEBUG_PASSWORD,
+	}
+
+	let credentials = {};
+	if (debugCreds.username && debugCreds.password) {
+		credentials = debugCreds;
+	} else {
+		// collect login details
+		credentials = await inquirer.prompt([
+			{
+				type: 'input',
+				name: 'username',
+				message: 'Enter your email address',
+				validate: (value) =>
+					value.length ? true : 'Please enter your email address',
+			},
+			{
+				type: 'password',
+				message: 'Enter your password',
+				name: 'password',
+				validate: (value) =>
+					value.length ? true : 'Please enter a password',
+			},
+		]);
+	}
 
 	// log the user in
 	let loginLoader = ora('Logging you in...').start();
@@ -50,6 +60,8 @@ export async function doLogin(message) {
 async function loginWith2FA(loginLoader, credentials, mfaStrategy) {
 	loginLoader.info(`Your account requires 2 factor authentication`);
 	let mfaType = mfaStrategy.mfaType;
+
+	// FIXME: This is legacy. We don't support Authy anymore.
 	if (mfaType === 'AUTHENTICATOR_APP' && mfaStrategy.hasAuthy) {
 		const choiceMfa = await selectMfaType();
 		mfaType = choiceMfa.mfaType;
@@ -70,6 +82,32 @@ async function loginWith2FA(loginLoader, credentials, mfaStrategy) {
 			}
 		}
 	}
+
+	let twoFactorId = mfaStrategy.twoFactorId;
+	let otpMethod = undefined;
+
+	if (mfaStrategy.moreOtpMethods) {
+		const choiceOtpMethod = await selectOtpMethod(mfaStrategy.moreOtpMethods);
+		otpMethod = choiceOtpMethod.otpMethod;
+
+		try {
+			await login({
+				...credentials,
+				mfaType,
+				otpMethod, // forces an specific OTP method
+				requestAdminToken: true,
+			});
+		} catch (e) {
+			if (requiresMfa(e)) {
+				const mfaStrategy = getMfaStrategy(e)
+				twoFactorId = mfaStrategy.twoFactorId;
+			} else {
+				error(e, loginLoader);
+				return false;
+			}
+		}
+	}
+
 	try {
 		const response = await inquirer.prompt([
 			{
@@ -90,12 +128,29 @@ async function loginWith2FA(loginLoader, credentials, mfaStrategy) {
 			mfaType,
 			otp: response.otp,
 			requestAdminToken: true,
+			twoFactorId,
+			otpMethod,
 		});
 		return loginSucceed(loginLoader, loginBody);
 	} catch (e) {
 		error(e, loginLoader);
 		return false;
 	}
+}
+
+async function selectOtpMethod(moreOtpMethods) {
+	const selectedOtpMethod = await inquirer.prompt([
+		{
+			type: 'list',
+			message: 'Select your preferred OTP method',
+			name: 'otpMethod',
+			choices: moreOtpMethods.map(method => ({
+				name: method,
+				value: method,
+			})),
+		},
+	]);
+	return selectedOtpMethod;
 }
 
 async function selectMfaType() {


### PR DESCRIPTION
## Summary
- Fixes the legacy CLI login flow so accounts requiring an additional verification step during MFA can complete sign-in successfully.
- Adds support for overriding the API base URL via an environment variable, to make it easier to test the CLI against non-production environments.

## Test plan
- [ ] Verify `raisely login` completes for an account with MFA enabled, including the additional verification step.
- [ ] Verify `raisely login` still works for accounts without MFA.
- [ ] Verify the API base URL override works as expected.