### PR TITLE
Skip non-directory entries when scanning the components directory

### DIFF
--- a/src/actions/components.js
+++ b/src/actions/components.js
@@ -110,6 +110,7 @@ export async function compileComponents() {
 	const componentsDir = path.join(process.cwd(), 'components');
 	const components = [];
 	for (const file of fs.readdirSync(componentsDir)) {
+		if (!fs.statSync(path.join(componentsDir, file)).isDirectory()) continue;
 		const component = {
 			name: file,
 			latestHtml: fs.readFileSync(

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -226,6 +226,7 @@ export default async function deploy(options = {}) {
 	const componentsDir = path.join(cwd, 'components');
 	if (fs.existsSync(componentsDir)) {
 		for (const file of fs.readdirSync(componentsDir)) {
+			if (!fs.statSync(path.join(componentsDir, file)).isDirectory()) continue;
 			const data = {
 				file: fs.readFileSync(path.join(componentsDir, file, `${file}.js`), 'utf8'),
 				config: JSON.parse(

--- a/tests/deploy.test.js
+++ b/tests/deploy.test.js
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => {
 		existsSync: vi.fn(),
 		readdirSync: vi.fn(),
 		readFileSync: vi.fn(),
+		statSync: vi.fn(),
 	};
 
 	const ora = vi.fn((label) => {
@@ -141,6 +142,7 @@ function setDefaultMocks() {
 		if (target === '/repo/components') return [];
 		return [];
 	});
+	mocks.fs.statSync.mockReturnValue({ isDirectory: () => true });
 }
 
 describe('deploy command', () => {
@@ -265,6 +267,31 @@ describe('deploy command', () => {
 
 		expect(mocks.uploadStyles).toHaveBeenCalledTimes(1);
 		expect(mocks.uploadPage).not.toHaveBeenCalled();
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	test('skips non-directory entries (e.g. .DS_Store) in the components directory', async () => {
+		mocks.fs.readdirSync.mockImplementation((target, options) => {
+			if (options && options.withFileTypes) return [];
+			if (target === '/repo/components') return ['.DS_Store', 'hero'];
+			return [];
+		});
+		mocks.fs.statSync.mockImplementation((target) => ({
+			isDirectory: () => !String(target).endsWith('.DS_Store'),
+		}));
+		mocks.fs.readFileSync.mockImplementation((target) => {
+			if (String(target).endsWith('hero.json')) return '{}';
+			return '';
+		});
+
+		await deploy({});
+
+		expect(mocks.fs.readFileSync).not.toHaveBeenCalledWith(
+			expect.stringContaining('.DS_Store'),
+			expect.anything()
+		);
+		expect(mocks.updateComponentConfig).toHaveBeenCalledTimes(1);
+		expect(mocks.updateComponentFile).toHaveBeenCalledTimes(1);
 		expect(process.exitCode).toBeUndefined();
 	});
 


### PR DESCRIPTION
## Summary

`deploy` and `compileComponents` both iterate `fs.readdirSync(componentsDir)` and immediately treat every entry as a component folder, reading `<entry>/<entry>.js` and `<entry>/<entry>.json`. A stray file directly in `components/` breaks this — most commonly macOS's `.DS_Store`, which every `raisely deploy` run on a Mac is liable to hit unless you remember to `.gitignore` it (and even then, it can reappear locally between deploys via Finder).

- `raisely deploy` throws `ENOTDIR` trying to open `.DS_Store/.DS_Store.js`
- `compileComponents` (used by `raisely start`/`local`) fails the same way

Both crash the whole command rather than just skipping the stray file.

## Fix

Skip any entry that isn't a directory before treating it as a component, in both `src/deploy.js` and `src/actions/components.js`.

## Test plan

- [x] Added a regression test in `tests/deploy.test.js` covering a `.DS_Store`-style entry alongside a real component
- [x] Confirmed the new test fails without the fix (`ENOTDIR`/JSON parse error depending on mock vs real fs) and passes with it
- [x] Full suite passes: `npm test` → 85/85

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small filesystem guard around existing scan loops; deploy preflight already filtered directories via `getComponentNames`.
> 
> **Overview**
> **Deploy** and **local component compilation** no longer treat every name under `components/` as a component folder. Both loops now call `fs.statSync` and **continue** when the entry is not a directory, so stray files like macOS `.DS_Store` are ignored instead of causing `ENOTDIR` or bad reads of `file/file.js`.
> 
> A **deploy regression test** simulates `.DS_Store` next to a real `hero` component and asserts only the real component is uploaded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0161b7d6686de0d907d55c06b676a2e2a65e147d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->